### PR TITLE
feat(dsl): add provider capacity metadata

### DIFF
--- a/onr-core/pkg/dslconfig/core_registry.go
+++ b/onr-core/pkg/dslconfig/core_registry.go
@@ -14,6 +14,7 @@ type ProviderFile struct {
 	Name     string
 	Path     string
 	Content  string
+	Metadata ProviderMetadata
 	Routing  ProviderRouting
 	Headers  ProviderHeaders
 	Request  ProviderRequestTransform

--- a/onr-core/pkg/dslconfig/core_registry_file.go
+++ b/onr-core/pkg/dslconfig/core_registry_file.go
@@ -137,7 +137,11 @@ func parseProvidersFromMergedFile(path string, content string, inherited modeReg
 			if err != nil {
 				return nil, nil, err
 			}
-			pf, err := buildMergedProviderFile(path, providerName, routing, headers, req, response, perr, usage, finish, balance, models, resolved)
+			metadata, err := parseProviderMetadataFromContent(path, content, providerName)
+			if err != nil {
+				return nil, nil, err
+			}
+			pf, err := buildMergedProviderFile(path, providerName, metadata, routing, headers, req, response, perr, usage, finish, balance, models, resolved)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -152,7 +156,7 @@ func parseProvidersFromMergedFile(path string, content string, inherited modeReg
 	return next, loaded, nil
 }
 
-func buildMergedProviderFile(path, providerName string, routing ProviderRouting, headers ProviderHeaders, req ProviderRequestTransform, response ProviderResponse, perr ProviderError, usage ProviderUsage, finish ProviderFinishReason, balance ProviderBalance, models ProviderModels, resolved modeRegistryState) (ProviderFile, error) {
+func buildMergedProviderFile(path, providerName string, metadata ProviderMetadata, routing ProviderRouting, headers ProviderHeaders, req ProviderRequestTransform, response ProviderResponse, perr ProviderError, usage ProviderUsage, finish ProviderFinishReason, balance ProviderBalance, models ProviderModels, resolved modeRegistryState) (ProviderFile, error) {
 	if err := validateProviderBaseURL(path, providerName, routing); err != nil {
 		return ProviderFile{}, err
 	}
@@ -182,6 +186,7 @@ func buildMergedProviderFile(path, providerName string, routing ProviderRouting,
 		Name:     providerName,
 		Path:     path,
 		Content:  "",
+		Metadata: metadata,
 		Routing:  routing,
 		Headers:  headers,
 		Request:  req,

--- a/onr-core/pkg/dslconfig/metadata.go
+++ b/onr-core/pkg/dslconfig/metadata.go
@@ -1,0 +1,158 @@
+package dslconfig
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ProviderMetadata describes provider identity and capacity signal profile.
+// Empty DSL fields are normalized at provider-file build time:
+// provider_family defaults to the provider name, and signal_profile defaults
+// to provider_family.
+type ProviderMetadata struct {
+	ProviderFamily string `json:"providerFamily,omitempty"`
+	SignalProfile  string `json:"signalProfile,omitempty"`
+}
+
+func normalizeProviderMetadata(providerName string, metadata ProviderMetadata) (ProviderMetadata, error) {
+	providerName = normalizeProviderName(providerName)
+	providerFamily := normalizeProviderName(metadata.ProviderFamily)
+	if providerFamily == "" {
+		providerFamily = providerName
+	}
+	signalProfile := normalizeProviderName(metadata.SignalProfile)
+	if signalProfile == "" {
+		signalProfile = providerFamily
+	}
+	out := ProviderMetadata{
+		ProviderFamily: providerFamily,
+		SignalProfile:  signalProfile,
+	}
+	if err := validateMetadataToken("provider_family", out.ProviderFamily); err != nil {
+		return ProviderMetadata{}, err
+	}
+	if err := validateMetadataToken("signal_profile", out.SignalProfile); err != nil {
+		return ProviderMetadata{}, err
+	}
+	return out, nil
+}
+
+func validateMetadataToken(field string, value string) error {
+	if !providerNamePattern.MatchString(value) {
+		return fmt.Errorf("invalid metadata %s %q, expected pattern %s", field, value, providerNamePattern.String())
+	}
+	return nil
+}
+
+func parseProviderMetadataFromContent(path string, content string, providerName string) (ProviderMetadata, error) {
+	s := newScanner(path, content)
+	want := normalizeProviderName(providerName)
+	for {
+		tok := s.nextNonTrivia()
+		if tok.kind == tokEOF {
+			return normalizeProviderMetadata(want, ProviderMetadata{})
+		}
+		if tok.kind != tokIdent || tok.text != providerKeyword {
+			continue
+		}
+		nameTok := s.nextNonTrivia()
+		if nameTok.kind != tokString {
+			return ProviderMetadata{}, s.errAt(nameTok, "expected provider name string literal")
+		}
+		lb := s.nextNonTrivia()
+		if lb.kind != tokLBrace {
+			return ProviderMetadata{}, s.errAt(lb, "expected '{' after provider name")
+		}
+		name := normalizeProviderName(unquoteString(nameTok.text))
+		if name != want {
+			if err := skipBalancedBraces(s); err != nil {
+				return ProviderMetadata{}, err
+			}
+			continue
+		}
+		return parseProviderMetadataBody(s, want)
+	}
+}
+
+func parseProviderMetadataBody(s *scanner, providerName string) (ProviderMetadata, error) {
+	var metadata ProviderMetadata
+	for {
+		tok := s.nextNonTrivia()
+		switch tok.kind {
+		case tokEOF:
+			return ProviderMetadata{}, s.errAt(tok, "unexpected EOF in provider block")
+		case tokRBrace:
+			return normalizeProviderMetadata(providerName, metadata)
+		case tokIdent:
+			if tok.text == "metadata" {
+				if err := parseMetadataBlock(s, &metadata); err != nil {
+					return ProviderMetadata{}, err
+				}
+				continue
+			}
+			if err := skipStmtOrBlock(s); err != nil {
+				return ProviderMetadata{}, err
+			}
+		default:
+			// Ignore trivia-like punctuation that the main parser already tolerates.
+		}
+	}
+}
+
+func parseMetadataBlock(s *scanner, metadata *ProviderMetadata) error {
+	lb := s.nextNonTrivia()
+	if lb.kind != tokLBrace {
+		return s.errAt(lb, "expected '{' after metadata")
+	}
+	for {
+		tok := s.nextNonTrivia()
+		switch tok.kind {
+		case tokEOF:
+			return s.errAt(tok, "unexpected EOF in metadata block")
+		case tokRBrace:
+			return nil
+		case tokIdent:
+			value, err := parseMetadataValueStmt(s, tok.text)
+			if err != nil {
+				return err
+			}
+			switch tok.text {
+			case "provider_family":
+				metadata.ProviderFamily = value
+			case "signal_profile":
+				metadata.SignalProfile = value
+			default:
+				return s.errAt(tok, "unknown metadata directive "+tok.text)
+			}
+		default:
+			return s.errAt(tok, "metadata directive expected")
+		}
+	}
+}
+
+func parseMetadataValueStmt(s *scanner, field string) (string, error) {
+	tok := s.nextNonTrivia()
+	switch tok.kind {
+	case tokIdent:
+		// ok
+	case tokString:
+		// quoted strings are accepted for compatibility, but new configs should use tokens.
+	default:
+		return "", s.errAt(tok, field+" expects identifier token")
+	}
+	if err := consumeSemicolon(s, field); err != nil {
+		return "", err
+	}
+	value := strings.TrimSpace(tok.text)
+	if tok.kind == tokString {
+		value = strings.TrimSpace(unquoteString(tok.text))
+	}
+	value = normalizeProviderName(value)
+	if value == "" {
+		return "", s.errAt(tok, field+" must be non-empty")
+	}
+	if err := validateMetadataToken(field, value); err != nil {
+		return "", s.errAt(tok, err.Error())
+	}
+	return value, nil
+}

--- a/onr-core/pkg/dslconfig/metadata_test.go
+++ b/onr-core/pkg/dslconfig/metadata_test.go
@@ -1,0 +1,160 @@
+package dslconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateProviderFile_MetadataExplicit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "azure-response.conf")
+	content := `syntax "next-router/0.1";
+
+provider "azure-response" {
+  metadata {
+    provider_family azure-openai;
+    signal_profile azure-openai;
+  }
+  defaults {
+    upstream_config {
+      base_url = "https://example.openai.azure.com";
+    }
+  }
+}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	pf, err := ValidateProviderFile(path)
+	if err != nil {
+		t.Fatalf("ValidateProviderFile: %v", err)
+	}
+	if got, want := pf.Metadata.ProviderFamily, "azure-openai"; got != want {
+		t.Fatalf("ProviderFamily=%q want %q", got, want)
+	}
+	if got, want := pf.Metadata.SignalProfile, "azure-openai"; got != want {
+		t.Fatalf("SignalProfile=%q want %q", got, want)
+	}
+}
+
+func TestValidateProviderFile_MetadataDefaults(t *testing.T) {
+	dir := t.TempDir()
+	writeProviderConf(t, dir, "openrouter", "https://openrouter.ai/api")
+
+	pf, err := ValidateProviderFile(filepath.Join(dir, "openrouter.conf"))
+	if err != nil {
+		t.Fatalf("ValidateProviderFile: %v", err)
+	}
+	if got, want := pf.Metadata.ProviderFamily, "openrouter"; got != want {
+		t.Fatalf("ProviderFamily=%q want %q", got, want)
+	}
+	if got, want := pf.Metadata.SignalProfile, "openrouter"; got != want {
+		t.Fatalf("SignalProfile=%q want %q", got, want)
+	}
+}
+
+func TestValidateProviderFile_MetadataSignalProfileDefaultsToFamily(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "partner-x.conf")
+	content := `provider "partner-x" {
+  metadata {
+    provider_family partner-aggregator;
+  }
+  defaults {
+    upstream_config {
+      base_url = "https://api.partner.example";
+    }
+  }
+}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	pf, err := ValidateProviderFile(path)
+	if err != nil {
+		t.Fatalf("ValidateProviderFile: %v", err)
+	}
+	if got, want := pf.Metadata.ProviderFamily, "partner-aggregator"; got != want {
+		t.Fatalf("ProviderFamily=%q want %q", got, want)
+	}
+	if got, want := pf.Metadata.SignalProfile, "partner-aggregator"; got != want {
+		t.Fatalf("SignalProfile=%q want %q", got, want)
+	}
+}
+
+func TestValidateProviderFile_MetadataRejectsInvalidToken(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demo.conf")
+	content := `provider "demo" {
+  metadata {
+    provider_family "Bad Value";
+  }
+  defaults {
+    upstream_config {
+      base_url = "https://api.example.com";
+    }
+  }
+}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := ValidateProviderFile(path)
+	if err == nil || !strings.Contains(err.Error(), "invalid metadata provider_family") {
+		t.Fatalf("ValidateProviderFile err=%v, want invalid provider_family", err)
+	}
+}
+
+func TestRegistryReloadFromFile_MetadataPerProvider(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "providers.conf")
+	content := `provider "alpha" {
+  metadata {
+    provider_family openai-compatible;
+    signal_profile generic;
+  }
+  defaults {
+    upstream_config {
+      base_url = "https://alpha.example.com";
+    }
+  }
+}
+
+provider "beta" {
+  defaults {
+    upstream_config {
+      base_url = "https://beta.example.com";
+    }
+  }
+}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	reg := NewRegistry()
+	if _, err := reg.ReloadFromFile(path); err != nil {
+		t.Fatalf("ReloadFromFile: %v", err)
+	}
+	alpha, ok := reg.GetProvider("alpha")
+	if !ok {
+		t.Fatalf("alpha provider missing")
+	}
+	if got, want := alpha.Metadata.ProviderFamily, "openai-compatible"; got != want {
+		t.Fatalf("alpha ProviderFamily=%q want %q", got, want)
+	}
+	if got, want := alpha.Metadata.SignalProfile, "generic"; got != want {
+		t.Fatalf("alpha SignalProfile=%q want %q", got, want)
+	}
+	beta, ok := reg.GetProvider("beta")
+	if !ok {
+		t.Fatalf("beta provider missing")
+	}
+	if got, want := beta.Metadata.ProviderFamily, "beta"; got != want {
+		t.Fatalf("beta ProviderFamily=%q want %q", got, want)
+	}
+	if got, want := beta.Metadata.SignalProfile, "beta"; got != want {
+		t.Fatalf("beta SignalProfile=%q want %q", got, want)
+	}
+}

--- a/onr-core/pkg/dslconfig/parse_provider.go
+++ b/onr-core/pkg/dslconfig/parse_provider.go
@@ -70,6 +70,10 @@ func parseProviderBody(s *scanner) (ProviderRouting, ProviderHeaders, ProviderRe
 			return routing, headers, req, response, perr, usage, finish, balance, models, nil
 		case tokIdent:
 			switch tok.text {
+			case "metadata":
+				if err := skipStmtOrBlock(s); err != nil {
+					return ProviderRouting{}, ProviderHeaders{}, ProviderRequestTransform{}, ProviderResponse{}, ProviderError{}, ProviderUsage{}, ProviderFinishReason{}, ProviderBalance{}, ProviderModels{}, err
+				}
 			case "defaults":
 				if err := parseDefaultsBlock(s, &routing, &headers, &req, &response, &perr, &usage, &finish, &balance, &models); err != nil {
 					return ProviderRouting{}, ProviderHeaders{}, ProviderRequestTransform{}, ProviderResponse{}, ProviderError{}, ProviderUsage{}, ProviderFinishReason{}, ProviderBalance{}, ProviderModels{}, err

--- a/onr-core/pkg/dslconfig/usage_modes.go
+++ b/onr-core/pkg/dslconfig/usage_modes.go
@@ -215,6 +215,10 @@ func validateAndBuildProviderFile(path string, content string, usageModes usageM
 	if err != nil {
 		return ProviderFile{}, false, err
 	}
+	metadata, err := parseProviderMetadataFromContent(path, content, providerName)
+	if err != nil {
+		return ProviderFile{}, false, err
+	}
 	if err := validateProviderBaseURL(path, providerName, routing); err != nil {
 		return ProviderFile{}, false, err
 	}
@@ -250,6 +254,7 @@ func validateAndBuildProviderFile(path string, content string, usageModes usageM
 		Name:     providerName,
 		Path:     path,
 		Content:  content,
+		Metadata: metadata,
 		Routing:  routing,
 		Headers:  headers,
 		Request:  req,

--- a/onr-core/pkg/dslspec/metadata.go
+++ b/onr-core/pkg/dslspec/metadata.go
@@ -38,6 +38,10 @@ var directiveMetadata = []DirectiveMetadata{
 
 	{Name: "defaults", Block: "provider", Hover: "`defaults { ... }`\n\nDefault phases shared by all `match` rules unless overridden."},
 	{Name: "match", Block: "provider", Hover: "`match api = \"...\" [stream = true|false] { ... }`\n\nRoute rule. First match wins."},
+	{Name: "metadata", Block: "provider", Hover: "`metadata { provider_family <family>; signal_profile <profile>; }`\n\nDeclares provider identity and capacity signal profile metadata."},
+
+	{Name: "provider_family", Block: "metadata", Hover: "`provider_family <family>;`\n\nProvider family used for operations, debug output, and later capacity-signal grouping."},
+	{Name: "signal_profile", Block: "metadata", Hover: "`signal_profile <profile>;`\n\nSignal profile used by later provider capacity signal adaptors."},
 
 	{Name: "upstream_config", Block: "defaults", Hover: "`upstream_config { base_url = \"...\"; }`\n\nProvider-level upstream base URL config."},
 	{Name: "auth", Block: "defaults", Hover: "`auth { ... }`\n\nAuthentication directives for upstream requests."},

--- a/onr-core/pkg/dslspec/parser_metadata_sync_test.go
+++ b/onr-core/pkg/dslspec/parser_metadata_sync_test.go
@@ -82,6 +82,7 @@ func parserDirectiveSources() []parserDirectiveSource {
 		{block: "top", fn: "parseGlobalModelsModes", kind: parserDirectiveSwitch},
 		{block: "top", fn: "parseGlobalBalanceModes", kind: parserDirectiveSwitch},
 		{block: "provider", fn: "parseProviderBody", kind: parserDirectiveSwitch},
+		{block: "metadata", fn: "parseMetadataBlock", kind: parserDirectiveSwitch},
 		{block: "upstream_config", fn: "parseUpstreamConfigBlock", kind: parserDirectiveStringEqual},
 		{block: "auth", fn: "parseAuthPhase", kind: parserDirectiveHandlerMap},
 		{block: "request", fn: "parseRequestPhaseWithTransform", kind: parserDirectiveHandlerMap},


### PR DESCRIPTION
## Summary

- Add provider-level capacity signal metadata to the DSL config model.
- Normalize `provider_family` and `signal_profile` with backward-compatible defaults.
- Preserve existing provider files by deriving missing metadata from the provider name.

## Validation

- `go test ./...`

## Test Strategy

- Added/updated DSL config tests for explicit metadata, default metadata, and invalid metadata handling.
- The tests protect the parser contract consumed by relay provider registry and signal classification follow-up work.

## Impact

- Affects `onr-core/pkg/dslconfig` and related DSL spec metadata handling.
- Existing DSL files remain compatible; metadata is additive and defaults are stable.
