### PR TITLE
Feat/sse format checker

### DIFF
--- a/onr-core/pkg/dslconfig/stream_format_check.go
+++ b/onr-core/pkg/dslconfig/stream_format_check.go
@@ -1,0 +1,318 @@
+package dslconfig
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/r9s-ai/open-next-router/onr-core/pkg/dslmeta"
+)
+
+type CheckResult struct {
+	ChunkCount int
+	Api        string
+	EventsSeen map[string]int
+	Payload    *PayloadCheckResult
+}
+
+type PayloadCheckResult struct {
+	CheckedCount int
+	ValidCount   int
+	InvalidCount int
+	Issues       []PayloadIssue
+}
+
+type PayloadIssue struct {
+	Event string
+	Code  string
+	Path  string
+}
+
+type StreamFormatChecker struct {
+	res *CheckResult
+}
+
+func NewStreamFormatChecker(meta *dslmeta.Meta) *StreamFormatChecker {
+	res := &CheckResult{}
+	if meta != nil {
+		res.Api = meta.API
+	}
+	return &StreamFormatChecker{res: res}
+}
+
+func (checker *StreamFormatChecker) OnSSEEventDataJSON(event string, payload []byte) error {
+	if checker.res == nil {
+		return nil
+	}
+	if len(payload) == 0 {
+		return nil
+	}
+	checker.res.ChunkCount += 1
+	rawEvent := strings.TrimSpace(event)
+	// Parse the JSON structure first and run lightweight field checks.
+	//
+	// The checker is observability-only and must not block SSE passthrough. Even
+	// when payload parsing fails, it still records chunk_count, event.seen, and
+	// payload issues so upstream access logs can show malformed upstream chunks
+	// without turning the response path into an error.
+	root, issues := parsePayload(rawEvent, payload)
+	// Decide how this chunk should be grouped under event.seen.
+	//
+	// When an SSE event field exists, it is authoritative. Otherwise infer from
+	// payload type / choices / candidates so data-only streams such as OpenAI chat
+	// and GLM chat do not all fall into fallback_data.
+	eventName := eventNameForPayload(rawEvent, root)
+	checker.recordEvent(eventName)
+	checker.recordPayloadCheck(eventName, issues)
+	return nil
+}
+
+func (checker *StreamFormatChecker) recordEvent(event string) {
+	event = strings.TrimSpace(event)
+	if event == "" {
+		event = "fallback_data"
+	}
+	if checker.res.EventsSeen == nil {
+		checker.res.EventsSeen = make(map[string]int)
+	}
+	checker.res.EventsSeen[event] += 1
+}
+
+func (checker *StreamFormatChecker) recordPayloadCheck(event string, issues []PayloadIssue) {
+	if checker.res.Payload == nil {
+		checker.res.Payload = &PayloadCheckResult{}
+	}
+	checker.res.Payload.CheckedCount += 1
+	if len(issues) == 0 {
+		checker.res.Payload.ValidCount += 1
+		return
+	}
+	checker.res.Payload.InvalidCount += 1
+	for _, issue := range issues {
+		if issue.Event == "" {
+			issue.Event = event
+		}
+		checker.res.Payload.Issues = append(checker.res.Payload.Issues, issue)
+	}
+}
+
+func parsePayload(rawEvent string, payload []byte) (map[string]any, []PayloadIssue) {
+	// The payload must be a JSON object.
+	//
+	// Keep two failure classes separate:
+	// 1. invalid_json: the payload is not valid JSON, such as partial JSON, plain
+	//    text, or broken upstream concatenation.
+	// 2. invalid_payload_root: the payload is valid JSON, but the root is not an
+	//    object, such as an array, string, or number.
+	//
+	// Normal provider SSE data chunks should usually be objects. [DONE] is
+	// filtered by the Tap layer before reaching this function.
+	var value any
+	if err := json.Unmarshal(payload, &value); err != nil {
+		return nil, []PayloadIssue{{
+			Event: fallbackEventName(rawEvent),
+			Code:  "invalid_json",
+		}}
+	}
+	root, ok := value.(map[string]any)
+	if !ok || root == nil {
+		return nil, []PayloadIssue{{
+			Event: fallbackEventName(rawEvent),
+			Code:  "invalid_payload_root",
+		}}
+	}
+	issues := payloadFieldIssues(rawEvent, root)
+	return root, issues
+}
+
+func payloadFieldIssues(rawEvent string, root map[string]any) []PayloadIssue {
+	var issues []PayloadIssue
+	// Only run non-blocking lightweight field shape checks here. Do not extract
+	// usage or finish_reason from this checker.
+	//
+	// Design boundary:
+	// - This checker records whether the payload looks like a chunk for a known
+	//   protocol shape.
+	// - DSL metrics performs the actual usage, finish_reason, and token
+	//   extraction.
+	// - Therefore missing fields are not errors here; only fields that are present
+	//   with clearly invalid types are reported.
+
+	// type:
+	// - OpenAI Responses / Anthropic Messages event streams usually put the event
+	//   name in payload.type.
+	// - If type exists but is not a string, the payload structure is malformed.
+	// - If an SSE event exists and payload.type differs, the upstream event/data
+	//   pair is inconsistent.
+	if value, ok := root["type"]; ok {
+		typ, typeOK := value.(string)
+		if !typeOK {
+			issues = append(issues, PayloadIssue{Code: "invalid_type_field", Path: "type"})
+		} else if rawEvent != "" && typ != rawEvent {
+			issues = append(issues, PayloadIssue{Event: rawEvent, Code: "event_type_mismatch", Path: "type"})
+		}
+	}
+	// object:
+	// - OpenAI chat completions commonly use object="chat.completion.chunk".
+	// - Compatible APIs such as GLM/Z.ai may omit object, so missing object is not
+	//   an error.
+	// - Only report invalid_object_field when object exists but is not a string.
+	if value, ok := root["object"]; ok {
+		if _, typeOK := value.(string); !typeOK {
+			issues = append(issues, PayloadIssue{Code: "invalid_object_field", Path: "object"})
+		}
+	}
+	// choices:
+	// - Chat completions streams such as OpenAI, DeepSeek, Minimax, and GLM are
+	//   primarily represented through choices.
+	// - choices should normally be an array; chunk/finish/usage classification is
+	//   handled by eventNameForPayload.
+	// - Missing choices is not an error because Responses, Anthropic, and Gemini do
+	//   not use this field.
+	if value, ok := root["choices"]; ok {
+		if _, typeOK := value.([]any); !typeOK {
+			issues = append(issues, PayloadIssue{Code: "invalid_choices_field", Path: "choices"})
+		}
+	}
+	// candidates:
+	// - Gemini native streamGenerateContent uses candidates.
+	// - candidates should normally be an array; finish chunks are inferred from
+	//   candidates[].finishReason.
+	// - Missing candidates is not an error because OpenAI/Anthropic paths do not
+	//   include this field.
+	if value, ok := root["candidates"]; ok {
+		if _, typeOK := value.([]any); !typeOK {
+			issues = append(issues, PayloadIssue{Code: "invalid_candidates_field", Path: "candidates"})
+		}
+	}
+	// usage:
+	// - OpenAI-compatible streams may include a final usage chunk, or omit usage
+	//   entirely.
+	// - usage=null is common in streaming chunks and is not an error.
+	// - Non-null usage should be an object; string/array/number values are
+	//   structural issues.
+	if value, ok := root["usage"]; ok && value != nil {
+		if _, typeOK := value.(map[string]any); !typeOK {
+			issues = append(issues, PayloadIssue{Code: "invalid_usage_field", Path: "usage"})
+		}
+	}
+	return issues
+}
+
+func eventNameForPayload(rawEvent string, root map[string]any) string {
+	// The SSE event field is the most reliable event name. Infer from provider
+	// payload shape only when event is missing.
+	//
+	// Keep this priority stable:
+	// 1. rawEvent: Anthropic/Responses and similar streams emit explicit events,
+	//    and logs should preserve the original event name.
+	// 2. payload.type: Anthropic/Responses data usually also has type, which can
+	//    classify data when event is absent.
+	// 3. choices: OpenAI-compatible chat completions usually omit event and must be
+	//    classified through choices/finish_reason.
+	// 4. candidates: Gemini native streamGenerateContent expresses chunks through
+	//    candidates/finishReason.
+	// 5. fallback_data: valid JSON without known protocol features, or payloads
+	//    that cannot be parsed.
+	if rawEvent != "" {
+		return rawEvent
+	}
+	if root == nil {
+		return "fallback_data"
+	}
+	if typ, ok := stringField(root, "type"); ok && typ != "" {
+		return typ
+	}
+	if choices, ok := arrayField(root, "choices"); ok {
+		return chatCompletionEventName(root, choices)
+	}
+	if candidates, ok := arrayField(root, "candidates"); ok {
+		return geminiEventName(candidates)
+	}
+	return "fallback_data"
+}
+
+func fallbackEventName(rawEvent string) string {
+	rawEvent = strings.TrimSpace(rawEvent)
+	if rawEvent != "" {
+		return rawEvent
+	}
+	return "fallback_data"
+}
+
+func chatCompletionEventName(root map[string]any, choices []any) string {
+	// OpenAI-compatible streams usually omit event; GLM and similar APIs may also
+	// omit object, so this only relies on choices/usage.
+	//
+	// Classification rules:
+	// - choices=[] with object usage: classify as an independent usage chunk.
+	// - choices[*].finish_reason as a non-empty string: classify as a finish chunk.
+	// - choices[*].finish_reason as a non-string non-nil value: also classify as a
+	//   finish chunk; more detailed field checks can report the shape issue later.
+	// - Other choices chunks are treated as regular content delta chunks.
+	if len(choices) == 0 {
+		if usage, ok := root["usage"].(map[string]any); ok && usage != nil {
+			return "chat.completion.usage"
+		}
+		return "chat.completion.chunk"
+	}
+	for _, item := range choices {
+		choice, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if finishReason, ok := choice["finish_reason"]; ok && finishReason != nil {
+			if finish, ok := finishReason.(string); !ok || strings.TrimSpace(finish) != "" {
+				return "chat.completion.finish"
+			}
+		}
+	}
+	return "chat.completion.chunk"
+}
+
+func geminiEventName(candidates []any) string {
+	// Gemini native streamGenerateContent uses candidates[].finishReason to signal
+	// finish chunks.
+	//
+	// Classification rules:
+	// - Any candidate with a non-empty string finishReason is a finish chunk.
+	// - A non-string non-nil finishReason is also treated as a finish chunk, so
+	//   malformed finish signals are not missed.
+	// - Missing or empty finishReason is treated as a regular content delta chunk.
+	for _, item := range candidates {
+		candidate, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if finishReason, ok := candidate["finishReason"]; ok && finishReason != nil {
+			if finish, ok := finishReason.(string); !ok || strings.TrimSpace(finish) != "" {
+				return "gemini.generate_content.finish"
+			}
+		}
+	}
+	return "gemini.generate_content.chunk"
+}
+
+func stringField(root map[string]any, key string) (string, bool) {
+	value, ok := root[key]
+	if !ok {
+		return "", false
+	}
+	text, ok := value.(string)
+	return text, ok
+}
+
+func arrayField(root map[string]any, key string) ([]any, bool) {
+	value, ok := root[key]
+	if !ok {
+		return nil, false
+	}
+	items, ok := value.([]any)
+	return items, ok
+}
+
+func (checker *StreamFormatChecker) Result() *CheckResult {
+	if checker == nil {
+		return nil
+	}
+	return checker.res
+}

--- a/onr-core/pkg/dslconfig/stream_format_check.go
+++ b/onr-core/pkg/dslconfig/stream_format_check.go
@@ -10,8 +10,12 @@ import (
 type CheckResult struct {
 	ChunkCount int
 	Api        string
-	EventsSeen map[string]int
+	Event      *EventCheckResult
 	Payload    *PayloadCheckResult
+}
+
+type EventCheckResult struct {
+	Seen map[string]int
 }
 
 type PayloadCheckResult struct {
@@ -71,10 +75,13 @@ func (checker *StreamFormatChecker) recordEvent(event string) {
 	if event == "" {
 		event = "fallback_data"
 	}
-	if checker.res.EventsSeen == nil {
-		checker.res.EventsSeen = make(map[string]int)
+	if checker.res.Event == nil {
+		checker.res.Event = &EventCheckResult{}
 	}
-	checker.res.EventsSeen[event] += 1
+	if checker.res.Event.Seen == nil {
+		checker.res.Event.Seen = make(map[string]int)
+	}
+	checker.res.Event.Seen[event] += 1
 }
 
 func (checker *StreamFormatChecker) recordPayloadCheck(event string, issues []PayloadIssue) {

--- a/onr-core/pkg/dslconfig/stream_format_check_test.go
+++ b/onr-core/pkg/dslconfig/stream_format_check_test.go
@@ -1,0 +1,118 @@
+package dslconfig
+
+import (
+	"testing"
+
+	"github.com/r9s-ai/open-next-router/onr-core/pkg/dslmeta"
+)
+
+func TestStreamFormatCheckerCountsEventPayloads(t *testing.T) {
+	t.Parallel()
+
+	checker := NewStreamFormatChecker(&dslmeta.Meta{API: "responses"})
+	if checker.Result() == nil {
+		t.Fatal("Result()=nil, want initialized result")
+	}
+
+	_ = checker.OnSSEEventDataJSON("response.created", []byte(`{"type":"response.created"}`))
+	_ = checker.OnSSEEventDataJSON("", []byte(`{"type":"response.output_text.delta"}`))
+	_ = checker.OnSSEEventDataJSON("response.completed", nil)
+	_ = checker.OnSSEEventDataJSON("response.completed", []byte(`{"type":"response.completed"}`))
+
+	res := checker.Result()
+	if got := res.Api; got != "responses" {
+		t.Fatalf("Api=%q want responses", got)
+	}
+	if got := res.ChunkCount; got != 3 {
+		t.Fatalf("ChunkCount=%d want 3", got)
+	}
+	if got := res.EventsSeen["response.created"]; got != 1 {
+		t.Fatalf("EventsSeen[response.created]=%d want 1", got)
+	}
+	if got := res.EventsSeen["response.output_text.delta"]; got != 1 {
+		t.Fatalf("EventsSeen[response.output_text.delta]=%d want 1", got)
+	}
+	if got := res.EventsSeen["response.completed"]; got != 1 {
+		t.Fatalf("EventsSeen[response.completed]=%d want 1", got)
+	}
+	if res.Payload == nil {
+		t.Fatal("Payload=nil, want payload summary")
+	}
+	if got := res.Payload.CheckedCount; got != 3 {
+		t.Fatalf("Payload.CheckedCount=%d want 3", got)
+	}
+	if got := res.Payload.ValidCount; got != 3 {
+		t.Fatalf("Payload.ValidCount=%d want 3", got)
+	}
+	if got := res.Payload.InvalidCount; got != 0 {
+		t.Fatalf("Payload.InvalidCount=%d want 0", got)
+	}
+}
+
+func TestStreamFormatCheckerClassifiesDataOnlyPayloads(t *testing.T) {
+	t.Parallel()
+
+	checker := NewStreamFormatChecker(&dslmeta.Meta{})
+	_ = checker.OnSSEEventDataJSON("", []byte(`{"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}`))
+	_ = checker.OnSSEEventDataJSON("", []byte(`{"choices":[{"delta":{},"finish_reason":"stop"}]}`))
+	_ = checker.OnSSEEventDataJSON("", []byte(`{"choices":[],"usage":{"prompt_tokens":1}}`))
+	_ = checker.OnSSEEventDataJSON("", []byte(`{"candidates":[{"content":{"parts":[{"text":"hi"}]}}]}`))
+	_ = checker.OnSSEEventDataJSON("", []byte(`{"candidates":[{"finishReason":"STOP"}]}`))
+
+	res := checker.Result()
+	assertEventCount(t, res.EventsSeen, "chat.completion.chunk", 1)
+	assertEventCount(t, res.EventsSeen, "chat.completion.finish", 1)
+	assertEventCount(t, res.EventsSeen, "chat.completion.usage", 1)
+	assertEventCount(t, res.EventsSeen, "gemini.generate_content.chunk", 1)
+	assertEventCount(t, res.EventsSeen, "gemini.generate_content.finish", 1)
+	if got := res.Payload.CheckedCount; got != 5 {
+		t.Fatalf("Payload.CheckedCount=%d want 5", got)
+	}
+	if got := res.Payload.ValidCount; got != 5 {
+		t.Fatalf("Payload.ValidCount=%d want 5", got)
+	}
+	if got := res.Payload.InvalidCount; got != 0 {
+		t.Fatalf("Payload.InvalidCount=%d want 0", got)
+	}
+}
+
+func TestStreamFormatCheckerRecordsPayloadIssues(t *testing.T) {
+	t.Parallel()
+
+	checker := NewStreamFormatChecker(&dslmeta.Meta{})
+	_ = checker.OnSSEEventDataJSON("", []byte(`not-json`))
+	_ = checker.OnSSEEventDataJSON("response.completed", []byte(`{"type":"response.created"}`))
+	_ = checker.OnSSEEventDataJSON("", []byte(`{"choices":{}}`))
+	_ = checker.OnSSEEventDataJSON("", []byte(`[{"type":"response.created"}]`))
+
+	res := checker.Result()
+	assertEventCount(t, res.EventsSeen, "fallback_data", 3)
+	assertEventCount(t, res.EventsSeen, "response.completed", 1)
+	if got := res.Payload.CheckedCount; got != 4 {
+		t.Fatalf("Payload.CheckedCount=%d want 4", got)
+	}
+	if got := res.Payload.InvalidCount; got != 4 {
+		t.Fatalf("Payload.InvalidCount=%d want 4", got)
+	}
+	assertIssue(t, res.Payload.Issues, "fallback_data", "invalid_json", "")
+	assertIssue(t, res.Payload.Issues, "response.completed", "event_type_mismatch", "type")
+	assertIssue(t, res.Payload.Issues, "fallback_data", "invalid_choices_field", "choices")
+	assertIssue(t, res.Payload.Issues, "fallback_data", "invalid_payload_root", "")
+}
+
+func assertEventCount(t *testing.T, events map[string]int, event string, want int) {
+	t.Helper()
+	if got := events[event]; got != want {
+		t.Fatalf("EventsSeen[%s]=%d want %d", event, got, want)
+	}
+}
+
+func assertIssue(t *testing.T, issues []PayloadIssue, event string, code string, path string) {
+	t.Helper()
+	for _, issue := range issues {
+		if issue.Event == event && issue.Code == code && issue.Path == path {
+			return
+		}
+	}
+	t.Fatalf("missing issue event=%q code=%q path=%q in %#v", event, code, path, issues)
+}

--- a/onr-core/pkg/dslconfig/stream_format_check_test.go
+++ b/onr-core/pkg/dslconfig/stream_format_check_test.go
@@ -26,14 +26,14 @@ func TestStreamFormatCheckerCountsEventPayloads(t *testing.T) {
 	if got := res.ChunkCount; got != 3 {
 		t.Fatalf("ChunkCount=%d want 3", got)
 	}
-	if got := res.EventsSeen["response.created"]; got != 1 {
-		t.Fatalf("EventsSeen[response.created]=%d want 1", got)
+	if got := res.Event.Seen["response.created"]; got != 1 {
+		t.Fatalf("Event.Seen[response.created]=%d want 1", got)
 	}
-	if got := res.EventsSeen["response.output_text.delta"]; got != 1 {
-		t.Fatalf("EventsSeen[response.output_text.delta]=%d want 1", got)
+	if got := res.Event.Seen["response.output_text.delta"]; got != 1 {
+		t.Fatalf("Event.Seen[response.output_text.delta]=%d want 1", got)
 	}
-	if got := res.EventsSeen["response.completed"]; got != 1 {
-		t.Fatalf("EventsSeen[response.completed]=%d want 1", got)
+	if got := res.Event.Seen["response.completed"]; got != 1 {
+		t.Fatalf("Event.Seen[response.completed]=%d want 1", got)
 	}
 	if res.Payload == nil {
 		t.Fatal("Payload=nil, want payload summary")
@@ -60,11 +60,11 @@ func TestStreamFormatCheckerClassifiesDataOnlyPayloads(t *testing.T) {
 	_ = checker.OnSSEEventDataJSON("", []byte(`{"candidates":[{"finishReason":"STOP"}]}`))
 
 	res := checker.Result()
-	assertEventCount(t, res.EventsSeen, "chat.completion.chunk", 1)
-	assertEventCount(t, res.EventsSeen, "chat.completion.finish", 1)
-	assertEventCount(t, res.EventsSeen, "chat.completion.usage", 1)
-	assertEventCount(t, res.EventsSeen, "gemini.generate_content.chunk", 1)
-	assertEventCount(t, res.EventsSeen, "gemini.generate_content.finish", 1)
+	assertEventCount(t, res.Event.Seen, "chat.completion.chunk", 1)
+	assertEventCount(t, res.Event.Seen, "chat.completion.finish", 1)
+	assertEventCount(t, res.Event.Seen, "chat.completion.usage", 1)
+	assertEventCount(t, res.Event.Seen, "gemini.generate_content.chunk", 1)
+	assertEventCount(t, res.Event.Seen, "gemini.generate_content.finish", 1)
 	if got := res.Payload.CheckedCount; got != 5 {
 		t.Fatalf("Payload.CheckedCount=%d want 5", got)
 	}
@@ -86,8 +86,8 @@ func TestStreamFormatCheckerRecordsPayloadIssues(t *testing.T) {
 	_ = checker.OnSSEEventDataJSON("", []byte(`[{"type":"response.created"}]`))
 
 	res := checker.Result()
-	assertEventCount(t, res.EventsSeen, "fallback_data", 3)
-	assertEventCount(t, res.EventsSeen, "response.completed", 1)
+	assertEventCount(t, res.Event.Seen, "fallback_data", 3)
+	assertEventCount(t, res.Event.Seen, "response.completed", 1)
 	if got := res.Payload.CheckedCount; got != 4 {
 		t.Fatalf("Payload.CheckedCount=%d want 4", got)
 	}
@@ -103,7 +103,7 @@ func TestStreamFormatCheckerRecordsPayloadIssues(t *testing.T) {
 func assertEventCount(t *testing.T, events map[string]int, event string, want int) {
 	t.Helper()
 	if got := events[event]; got != want {
-		t.Fatalf("EventsSeen[%s]=%d want %d", event, got, want)
+		t.Fatalf("Event.Seen[%s]=%d want %d", event, got, want)
 	}
 }
 

--- a/onr-core/pkg/ssemetrics/tap.go
+++ b/onr-core/pkg/ssemetrics/tap.go
@@ -22,9 +22,6 @@ func NewSSEEventHandlerChain(handlers ...EventDataHandler) *SSEEventHandlerChain
 }
 
 func (h *SSEEventHandlerChain) OnSSEEventDataJSON(event string, payload []byte) error {
-	if h == nil {
-		return nil
-	}
 	for _, handler := range h.handlers {
 		if handler == nil {
 			continue

--- a/onr-core/pkg/ssemetrics/tap.go
+++ b/onr-core/pkg/ssemetrics/tap.go
@@ -10,6 +10,30 @@ type EventDataHandler interface {
 	OnSSEEventDataJSON(event string, payload []byte) error
 }
 
+type SSEEventHandlerChain struct {
+	handlers []EventDataHandler
+}
+
+func NewSSEEventHandlerChain(handlers ...EventDataHandler) *SSEEventHandlerChain {
+	chain := &SSEEventHandlerChain{}
+	chain.handlers = append(chain.handlers, handlers...)
+	return chain
+
+}
+
+func (h *SSEEventHandlerChain) OnSSEEventDataJSON(event string, payload []byte) error {
+	if h == nil {
+		return nil
+	}
+	for _, handler := range h.handlers {
+		if handler == nil {
+			continue
+		}
+		_ = handler.OnSSEEventDataJSON(event, payload)
+	}
+	return nil
+}
+
 // Tap incrementally parses SSE framing and forwards complete event/data payloads.
 //
 // It is intentionally transport-agnostic: callers may feed raw bytes via Write,

--- a/onr-core/pkg/ssemetrics/tap_test.go
+++ b/onr-core/pkg/ssemetrics/tap_test.go
@@ -1,6 +1,7 @@
 package ssemetrics
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -106,5 +107,37 @@ func TestTap_SkipsDonePayload(t *testing.T) {
 
 	if len(handler.events) != 0 {
 		t.Fatalf("events=%v want none", handler.events)
+	}
+}
+
+type erroringHandler struct {
+	err error
+}
+
+func (h erroringHandler) OnSSEEventDataJSON(string, []byte) error {
+	return h.err
+}
+
+func TestSSEEventHandlerChain_ForwardsToAllHandlers(t *testing.T) {
+	t.Parallel()
+
+	first := &recordingHandler{}
+	second := &recordingHandler{}
+	chain := NewSSEEventHandlerChain(nil, first, erroringHandler{err: errors.New("ignored")}, second)
+
+	if err := chain.OnSSEEventDataJSON("response.completed", []byte(`{"ok":true}`)); err != nil {
+		t.Fatalf("OnSSEEventDataJSON err=%v, want nil", err)
+	}
+
+	for name, handler := range map[string]*recordingHandler{
+		"first":  first,
+		"second": second,
+	} {
+		if len(handler.events) != 1 || handler.events[0] != "response.completed" {
+			t.Fatalf("%s events=%v want [response.completed]", name, handler.events)
+		}
+		if len(handler.payloads) != 1 || handler.payloads[0] != `{"ok":true}` {
+			t.Fatalf("%s payloads=%v want payload", name, handler.payloads)
+		}
 	}
 }


### PR DESCRIPTION

## Description

Adds reusable SSE event handling support and a stream format checker for SSE JSON payloads.

This change introduces:
- A shared `SSEEventHandlerChain` in `onr-core/pkg/ssemetrics` for forwarding parsed SSE event/data payloads to multiple handlers.
- A `StreamFormatChecker` in `onr-core/pkg/dslconfig` that records stream chunk counts, observed event names, payload validation counts, and lightweight payload shape issues.
- Unit coverage for SSE framing, `[DONE]` filtering, large chunk handling, handler chaining, stream event classification, and invalid payload reporting.

This is currently core/library-level support and does not add implicit proxy behavior.

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring

## How Has This Been Tested?

- [ ] Manual test
- [x] Unit test
- [ ] Integration test

Tested with:

```bash
go test ./onr-core/pkg/dslconfig ./onr-core/pkg/ssemetrics
go test ./...
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
```