### PR TITLE
fix(bedrock): apply dsl headers to mantle passthrough

### DIFF
--- a/onr/internal/proxy/bedrock.go
+++ b/onr/internal/proxy/bedrock.go
@@ -20,11 +20,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 	"github.com/gin-gonic/gin"
 
+	"github.com/r9s-ai/open-next-router/onr-core/pkg/dslconfig"
 	"github.com/r9s-ai/open-next-router/onr-core/pkg/dslmeta"
 	"github.com/r9s-ai/open-next-router/onr-core/pkg/trafficdump"
 )
 
-func (c *Client) doBedrockRuntimeRequest(gc *gin.Context, provider string, m *dslmeta.Meta, reqBody []byte) (*http.Response, context.CancelFunc, error) {
+func (c *Client) doBedrockRuntimeRequest(gc *gin.Context, provider string, pf *dslconfig.ProviderFile, m *dslmeta.Meta, reqBody []byte) (*http.Response, context.CancelFunc, error) {
 	operation, _, err := bedrockRuntimeTarget(m.RequestURLPath)
 	if err != nil {
 		return nil, func() {}, err
@@ -35,13 +36,13 @@ func (c *Client) doBedrockRuntimeRequest(gc *gin.Context, provider string, m *ds
 	case "invoke-with-response-stream":
 		return c.doBedrockInvokeModelStream(gc, provider, m, reqBody)
 	case "http-passthrough":
-		return c.doBedrockHTTPPassthrough(gc, provider, m, reqBody)
+		return c.doBedrockHTTPPassthrough(gc, provider, pf, m, reqBody)
 	default:
 		return nil, func() {}, fmt.Errorf("unsupported bedrock operation: %s", operation)
 	}
 }
 
-func (c *Client) doBedrockHTTPPassthrough(gc *gin.Context, provider string, m *dslmeta.Meta, reqBody []byte) (*http.Response, context.CancelFunc, error) {
+func (c *Client) doBedrockHTTPPassthrough(gc *gin.Context, provider string, pf *dslconfig.ProviderFile, m *dslmeta.Meta, reqBody []byte) (*http.Response, context.CancelFunc, error) {
 	reqCtx, cancel := context.WithTimeout(gc.Request.Context(), c.WriteTimeout)
 	httpc, err := c.httpClientForProvider(provider)
 	if err != nil {
@@ -65,6 +66,9 @@ func (c *Client) doBedrockHTTPPassthrough(gc *gin.Context, provider string, m *d
 	}
 	if accept := strings.TrimSpace(gc.Request.Header.Get("Accept")); accept != "" {
 		req.Header.Set("Accept", accept)
+	}
+	if pf != nil {
+		pf.Headers.Apply(m, gc.Request.Header, req.Header)
 	}
 	if err := signBedrockHTTPRequest(reqCtx, req, m, reqBody); err != nil {
 		cancel()

--- a/onr/internal/proxy/e2e_mock_test.go
+++ b/onr/internal/proxy/e2e_mock_test.go
@@ -267,6 +267,66 @@ func TestE2EMock_ChatCompletions_AWSBedrockNativeChatCompletions(t *testing.T) {
 	}
 }
 
+func TestE2EMock_ClaudeMessages_AWSBedrockMantleAppliesDSLHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mockResp := []byte(`{"id":"msg_bedrock","type":"message","role":"assistant","model":"anthropic.claude-haiku-4-5-20251001-v1:0","content":[{"type":"text","text":"OK"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`)
+	reqBody := []byte(`{"model":"anthropic.claude-haiku-4-5-20251001-v1:0","max_tokens":16,"stream_options":{"include_usage":true},"messages":[{"role":"user","content":"hi"}]}`)
+
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/anthropic/v1/messages" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("anthropic-version"); got != "2023-06-01" {
+			t.Fatalf("anthropic-version=%q want 2023-06-01", got)
+		}
+		if got := r.Header.Get("anthropic-beta"); got != "context-management-2025-06-27" {
+			t.Fatalf("anthropic-beta=%q want context-management-2025-06-27", got)
+		}
+		authHeader := r.Header.Get("Authorization")
+		if !strings.Contains(authHeader, "AWS4-HMAC-SHA256") || !strings.Contains(authHeader, "SignedHeaders=") {
+			t.Fatalf("unexpected Authorization header: %q", authHeader)
+		}
+		if !strings.Contains(authHeader, "anthropic-version") || !strings.Contains(authHeader, "anthropic-beta") {
+			t.Fatalf("Authorization header did not sign DSL headers: %q", authHeader)
+		}
+		var req map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		if _, ok := req["stream_options"]; ok {
+			t.Fatalf("stream_options should be removed, body=%#v", req)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(mockResp)
+	}))
+	t.Cleanup(mock.Close)
+
+	c := newMockE2EClient(t, map[string]string{
+		"aws-bedrock-mantle.conf": providerConfAWSBedrockMantle(mock.URL),
+	})
+	gc, rec := newGinJSONRequestPath(t, "/v1/messages", reqBody)
+	gc.Request.Header.Set("anthropic-beta", "context-management-2025-06-27, unsupported-beta")
+	res, err := c.ProxyJSON(gc, "aws-bedrock-mantle", ProviderKey{
+		Name:               "bedrock-key",
+		AWSAccessKeyID:     "AKID",
+		AWSSecretAccessKey: "SECRET",
+		AWSRegion:          "us-east-1",
+	}, "claude.messages", false)
+	if err != nil {
+		t.Fatalf("proxy error: %v", err)
+	}
+	if res == nil || res.Status != http.StatusOK {
+		t.Fatalf("unexpected result: %#v", res)
+	}
+	if got := rec.Code; got != http.StatusOK {
+		t.Fatalf("unexpected status: %d", got)
+	}
+}
+
 func TestE2EMock_ChatCompletions_AnthropicMessages_StreamToolUse(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -1446,6 +1506,19 @@ provider "aws-bedrock-mantle" {
     }
     upstream {
       set_path "/v1/chat/completions";
+    }
+  }
+
+  match api = "claude.messages" stream = false {
+    request {
+      model_map_default $request.model;
+      json_del "$.stream_options";
+      set_header "anthropic-version" "2023-06-01";
+      pass_header "anthropic-beta";
+      filter_header_values "anthropic-beta" "unsupported-*";
+    }
+    upstream {
+      set_path "/anthropic/v1/messages";
     }
   }
 }

--- a/onr/internal/proxy/upstream.go
+++ b/onr/internal/proxy/upstream.go
@@ -21,7 +21,7 @@ import (
 // doUpstreamRequest requires a non-nil provider file and request meta from buildProxyCtx.
 func (c *Client) doUpstreamRequest(gc *gin.Context, provider string, pf *dslconfig.ProviderFile, m *dslmeta.Meta, reqBody []byte) (*http.Response, context.CancelFunc, error) {
 	if strings.EqualFold(strings.TrimSpace(m.UpstreamTransport), "aws_sdk") {
-		return c.doBedrockRuntimeRequest(gc, provider, m, reqBody)
+		return c.doBedrockRuntimeRequest(gc, provider, pf, m, reqBody)
 	}
 	baseURL := m.BaseURL
 	if baseURL == "" {


### PR DESCRIPTION
## Description

Apply provider DSL request headers to Bedrock HTTP passthrough requests before SigV4 signing, so Mantle Anthropic Messages can send `anthropic-version` and filtered `anthropic-beta` headers.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

- [x] Manual test
- [x] Unit test
- [x] Integration test

Commands run:

```bash
go test ./onr/internal/proxy -run 'AWSBedrockMantle|Mantle|Bedrock' -count=1\ngo test ./onr/internal/proxy ./onr-core/pkg/dslconfig ./onr-core/pkg/modelsquery ./onr-admin/internal/cli -count=1\ngo run ./cmd/onr-pack --providers config/onr.conf --check-only\ngo run ./cmd/onr-admin validate providers --config config/onr.example.yaml\n```\n\n## Checklist:\n\n- [x] My code follows the style guidelines of this project\n- [x] I have performed a self-review of my own code\n- [ ] I have commented my code, particularly in hard-to-understand areas\n- [ ] I have made corresponding changes to the documentation\n- [x] My changes generate no new warnings\n- [x] Any dependent changes have been merged and published in downstream modules\n