### PR TITLE
feat(bench): add request-side DSL directive and transform pipeline benchmarks

### DIFF
--- a/onr-core/pkg/dslconfig/request_directive_benchmark_test.go
+++ b/onr-core/pkg/dslconfig/request_directive_benchmark_test.go
@@ -1,0 +1,152 @@
+package dslconfig
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/r9s-ai/open-next-router/onr-core/pkg/dslmeta"
+)
+
+// Request-side directive benchmarks, ordered by directive frequency across
+// production provider configs (set_path/match > json_del > json_replace >
+// json_set). Each op benchmarks a light (~200B) and a large (~33KB) request
+// body where payload size affects the work done.
+//
+// ApplyJSONOps mutates the root in place, so benchmarks that measure a
+// destructive op (del) rebuild the input each iteration and exclude the
+// rebuild cost via timer control; idempotent ops (set/replace to a constant)
+// reuse one root.
+
+func benchmarkChatRoot(extraBytes int) map[string]any {
+	content := "Summarize the benefits of using Next Router."
+	if extraBytes > 0 {
+		para := "China is one of the most geographically diverse countries. "
+		content = strings.Repeat(para, extraBytes/len(para)+1)[:extraBytes]
+	}
+	return map[string]any{
+		"model":  "gpt-4o-mini",
+		"stream": false,
+		"messages": []any{
+			map[string]any{"role": "system", "content": "You are a helpful assistant."},
+			map[string]any{"role": "user", "content": content},
+		},
+		"max_tokens":       500,
+		"stream_options":   map[string]any{"include_usage": true},
+		"inference_geo":    "us",
+		"speed":            "fast",
+		"reasoning_effort": "low",
+	}
+}
+
+func benchmarkApplyJSONOps(b *testing.B, ops []JSONOp, extraBytes int, rebuildEachIter bool) {
+	b.Helper()
+	meta := &dslmeta.Meta{API: "chat.completions"}
+	root := benchmarkChatRoot(extraBytes)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if rebuildEachIter {
+			b.StopTimer()
+			root = benchmarkChatRoot(extraBytes)
+			b.StartTimer()
+		}
+		if _, err := ApplyJSONOps(meta, root, ops); err != nil {
+			b.Fatalf("ApplyJSONOps: %v", err)
+		}
+	}
+}
+
+func BenchmarkJSONDel_Light(b *testing.B) {
+	ops := []JSONOp{
+		{Op: jsonOpDel, Path: "$.inference_geo"},
+		{Op: jsonOpDel, Path: "$.speed"},
+		{Op: jsonOpDel, Path: "$.reasoning_effort"},
+	}
+	benchmarkApplyJSONOps(b, ops, 0, true)
+}
+
+func BenchmarkJSONDel_Large(b *testing.B) {
+	ops := []JSONOp{
+		{Op: jsonOpDel, Path: "$.inference_geo"},
+		{Op: jsonOpDel, Path: "$.speed"},
+		{Op: jsonOpDel, Path: "$.reasoning_effort"},
+	}
+	benchmarkApplyJSONOps(b, ops, 33000, true)
+}
+
+func BenchmarkJSONSet_Light(b *testing.B) {
+	ops := []JSONOp{{Op: jsonOpSet, Path: "$.stream_options.include_usage", ValueExpr: "true"}}
+	benchmarkApplyJSONOps(b, ops, 0, false)
+}
+
+func BenchmarkJSONSet_Large(b *testing.B) {
+	ops := []JSONOp{{Op: jsonOpSet, Path: "$.stream_options.include_usage", ValueExpr: "true"}}
+	benchmarkApplyJSONOps(b, ops, 33000, false)
+}
+
+func BenchmarkJSONReplace_Light(b *testing.B) {
+	ops := []JSONOp{{Op: jsonOpReplace, Path: "$.model", ValueExpr: `"gpt-4o-mini-mapped"`}}
+	benchmarkApplyJSONOps(b, ops, 0, false)
+}
+
+func BenchmarkJSONReplace_Large(b *testing.B) {
+	ops := []JSONOp{{Op: jsonOpReplace, Path: "$.model", ValueExpr: `"gpt-4o-mini-mapped"`}}
+	benchmarkApplyJSONOps(b, ops, 33000, false)
+}
+
+// BenchmarkRoutingApply covers the match + set_path directives (the most
+// frequent pair: every request resolves upstream path through them).
+func BenchmarkRoutingApply(b *testing.B) {
+	routing := &ProviderRouting{
+		Matches: []RoutingMatch{
+			{API: "claude.messages", SetPath: `"/v1/messages"`},
+			{API: "embeddings", SetPath: `"/v1/embeddings"`},
+			{API: "chat.completions", SetPath: `"/v1/chat/completions"`},
+		},
+	}
+	meta := &dslmeta.Meta{API: "chat.completions"}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := routing.Apply(meta); err != nil {
+			b.Fatalf("routing.Apply: %v", err)
+		}
+	}
+}
+
+func BenchmarkRoutingApply_SetPathExpr(b *testing.B) {
+	routing := &ProviderRouting{
+		Matches: []RoutingMatch{
+			{API: "chat.completions", SetPath: `"/v1beta/models/" + $model + ":generateContent"`},
+		},
+	}
+	meta := &dslmeta.Meta{API: "chat.completions", DSLModelMapped: "gemini-2.5-flash"}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := routing.Apply(meta); err != nil {
+			b.Fatalf("routing.Apply: %v", err)
+		}
+	}
+}
+
+// sink prevents dead-code elimination of marshal results.
+var benchmarkSink []byte
+
+// BenchmarkMarshalRoot_Large isolates the re-marshal cost that any changed
+// json op incurs on a large body (the dominant term of request-side memory
+// amplification observed in relay profiling).
+func BenchmarkMarshalRoot_Large(b *testing.B) {
+	root := benchmarkChatRoot(33000)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		out, err := json.Marshal(root)
+		if err != nil {
+			b.Fatalf("marshal: %v", err)
+		}
+		benchmarkSink = out
+	}
+}

--- a/onr-core/pkg/requesttransform/requesttransform_benchmark_test.go
+++ b/onr-core/pkg/requesttransform/requesttransform_benchmark_test.go
@@ -1,0 +1,121 @@
+package requesttransform
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/r9s-ai/open-next-router/onr-core/pkg/dslconfig"
+	"github.com/r9s-ai/open-next-router/onr-core/pkg/dslmeta"
+)
+
+// Full request-transform pipeline benchmarks. Apply is on every relay request
+// path (config-file API type); req_map modes additionally cover the protocol
+// conversion pipelines (openai chat <-> anthropic/gemini). Light (~200B) and
+// large (~33KB) request bodies bracket the payload range seen in relay perf
+// baselines.
+
+func benchmarkChatBody(extraBytes int) ([]byte, map[string]any) {
+	content := "Summarize the benefits of using Next Router."
+	if extraBytes > 0 {
+		para := "China is one of the most geographically diverse countries. "
+		content = strings.Repeat(para, extraBytes/len(para)+1)[:extraBytes]
+	}
+	root := map[string]any{
+		"model":  "gpt-4o-mini",
+		"stream": false,
+		"messages": []any{
+			map[string]any{"role": "system", "content": "You are a helpful assistant."},
+			map[string]any{"role": "user", "content": content},
+		},
+		"max_tokens": 500,
+	}
+	body, err := json.Marshal(root)
+	if err != nil {
+		panic(err)
+	}
+	return body, root
+}
+
+func parseRoot(body []byte) map[string]any {
+	var root map[string]any
+	if err := json.Unmarshal(body, &root); err != nil {
+		panic(err)
+	}
+	return root
+}
+
+// benchmarkApply runs Apply with a fresh parsed root each iteration
+// (Apply mutates the root in place); parsing cost is excluded via timer control.
+func benchmarkApply(b *testing.B, t *dslconfig.RequestTransform, extraBytes int, mappedModel string) {
+	b.Helper()
+	body, _ := benchmarkChatBody(extraBytes)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		root := parseRoot(body)
+		meta := &dslmeta.Meta{API: "chat.completions", DSLModelMapped: mappedModel}
+		b.StartTimer()
+		if _, err := Apply(meta, "application/json", body, root, t, ApplyOptions{}); err != nil {
+			b.Fatalf("Apply: %v", err)
+		}
+	}
+}
+
+// Passthrough: no ops, no model change — the cheapest path (body reused as-is).
+func BenchmarkApply_Passthrough_Light(b *testing.B) {
+	benchmarkApply(b, &dslconfig.RequestTransform{}, 0, "")
+}
+
+func BenchmarkApply_Passthrough_Large(b *testing.B) {
+	benchmarkApply(b, &dslconfig.RequestTransform{}, 33000, "")
+}
+
+// ModelRemap: only the model field changes — triggers a full re-marshal of the
+// body (the dominant request-side memory amplification term in relay profiling).
+func BenchmarkApply_ModelRemap_Light(b *testing.B) {
+	benchmarkApply(b, &dslconfig.RequestTransform{}, 0, "gpt-4o-mini-mapped")
+}
+
+func BenchmarkApply_ModelRemap_Large(b *testing.B) {
+	benchmarkApply(b, &dslconfig.RequestTransform{}, 33000, "gpt-4o-mini-mapped")
+}
+
+// JSONOps: model remap + a realistic op mix (set stream option, delete two
+// unsupported fields) — the common non-req_map provider patch path.
+func benchmarkJSONOpsTransform() *dslconfig.RequestTransform {
+	return &dslconfig.RequestTransform{
+		JSONOps: []dslconfig.JSONOp{
+			{Op: "json_set", Path: "$.stream_options.include_usage", ValueExpr: "true"},
+			{Op: "json_del", Path: "$.inference_geo"},
+			{Op: "json_del", Path: "$.speed"},
+		},
+	}
+}
+
+func BenchmarkApply_JSONOps_Light(b *testing.B) {
+	benchmarkApply(b, benchmarkJSONOpsTransform(), 0, "gpt-4o-mini-mapped")
+}
+
+func BenchmarkApply_JSONOps_Large(b *testing.B) {
+	benchmarkApply(b, benchmarkJSONOpsTransform(), 33000, "gpt-4o-mini-mapped")
+}
+
+// ReqMap: protocol conversion pipelines (typed parse -> map -> re-marshal).
+func BenchmarkApply_ReqMapOpenAIToAnthropic_Light(b *testing.B) {
+	benchmarkApply(b, &dslconfig.RequestTransform{ReqMapMode: "openai_chat_to_anthropic_messages"}, 0, "")
+}
+
+func BenchmarkApply_ReqMapOpenAIToAnthropic_Large(b *testing.B) {
+	benchmarkApply(b, &dslconfig.RequestTransform{ReqMapMode: "openai_chat_to_anthropic_messages"}, 33000, "")
+}
+
+func BenchmarkApply_ReqMapOpenAIToGemini_Light(b *testing.B) {
+	benchmarkApply(b, &dslconfig.RequestTransform{ReqMapMode: "openai_chat_to_gemini_generate_content"}, 0, "")
+}
+
+func BenchmarkApply_ReqMapOpenAIToGemini_Large(b *testing.B) {
+	benchmarkApply(b, &dslconfig.RequestTransform{ReqMapMode: "openai_chat_to_gemini_generate_content"}, 33000, "")
+}


### PR DESCRIPTION
## Description

Adds Go benchmarks for the request-side DSL directives and the full request-transform pipeline. Existing benchmarks only cover the response side (usage/finish_reason extraction, stream metrics aggregation); the request-side directives — the most frequently used across production provider configs (`set_path`/`match` 171x, `json_del` 48x, `json_replace` 31x, `json_set` 20x) — had none.

**New benchmarks:**

- `pkg/dslconfig/request_directive_benchmark_test.go` — directive level: `json_del` / `json_set` / `json_replace` (light ~200B / large ~33KB payload tiers), routing `match`+`set_path` (constant path and string-expr variants), and an isolated re-marshal benchmark.
- `pkg/requesttransform/requesttransform_benchmark_test.go` — pipeline level: `Apply` across passthrough / model-remap / json-ops mix / `req_map` protocol conversions (openai→anthropic, openai→gemini), light/large bodies.

**Baseline numbers (8C Haswell, for future benchstat comparison):**

| benchmark | ns/op | B/op |
|---|---|---|
| Apply passthrough large | 511 | 0 |
| Apply model-remap large | 88,690 | 43,050 |
| Apply json-ops large | 85,287 | 43,542 |
| Apply req_map→anthropic large | 102,367 | 46,554 |
| json_del (3 ops) | ~2,200 | 96 |
| json_set / json_replace | ~400-520 | 48-64 |
| routing set_path const / expr | 943 / 2,541 | 224 / 432 |

Key finding these encode as a regression guard: **individual directive logic is ns-scale and payload-independent; ~99% of large-body transform cost is the body re-marshal triggered by any change** (passthrough vs model-remap on 33KB = ~170x). This quantifies the optimization headroom for in-place field rewriting on the model-remap-only path, and `req_map` typed-mapping overhead (~12us) is negligible against the marshal term.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual test — full bench run: `go test ./pkg/dslconfig ./pkg/requesttransform -bench . -benchtime 1s` (numbers above); regular `go test` on both packages passes; `go vet` clean.
- [ ] Unit test (benchmarks only; no behavior change)
- [ ] Integration test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

🤖 Generated with [Claude Code](https://claude.com/claude-code)