### PR TITLE
fix(dslconfig): resolve the request transform on the merged-file load path

### DIFF
--- a/config/providers/minimax.conf
+++ b/config/providers/minimax.conf
@@ -77,6 +77,11 @@ provider "minimax" {
     metrics {
       # minimax 图像响应没有 token 用量,按张数计费;此处读的是映射后的
       # OpenAI 形状(data 已是数组)。
+      #
+      # relay-config 的同名 conf 有意不配这一条:relay 的按张计费走模型定价里的
+      # pricing.output.image,再产出 image.generate fact 会有双重计费风险。onr
+      # 没有那套 extractor,产出的 image_generate_images 是它唯一的图像计费依据
+      # (pricing 的 extra usage rate 按这个 key 查费率),所以这里必须保留。
       usage_fact image.generate image source="response" count_path="$.data[*]";
     }
   }

--- a/config/providers/minimax.conf
+++ b/config/providers/minimax.conf
@@ -78,10 +78,10 @@ provider "minimax" {
       # minimax 图像响应没有 token 用量,按张数计费;此处读的是映射后的
       # OpenAI 形状(data 已是数组)。
       #
-      # relay-config 的同名 conf 有意不配这一条:relay 的按张计费走模型定价里的
-      # pricing.output.image,再产出 image.generate fact 会有双重计费风险。onr
-      # 没有那套 extractor,产出的 image_generate_images 是它唯一的图像计费依据
-      # (pricing 的 extra usage rate 按这个 key 查费率),所以这里必须保留。
+      # 这条 fact 是两边的按张计费取数来源,relay-config 的同名 conf 也有它。
+      # relay 侧对应模型定价里的 usage_facts.image.generate(admin 界面标注为
+      # "推荐优先在这里配置");onr 侧对应 pricing 的 extra usage rate,按
+      # image_generate_images 这个 key 查费率。
       usage_fact image.generate image source="response" count_path="$.data[*]";
     }
   }

--- a/onr-core/pkg/dslconfig/core_registry_file.go
+++ b/onr-core/pkg/dslconfig/core_registry_file.go
@@ -166,7 +166,18 @@ func buildMergedProviderFile(path, providerName string, metadata ProviderMetadat
 	if err := validateProviderRouting(path, providerName, routing); err != nil {
 		return ProviderFile{}, err
 	}
+	// Request must go through its resolver, not be stored as parsed: the resolver
+	// compiles the execution-plan fields the runtime indexes into, such as a
+	// validation rule's body path parts. Storing the parsed value left those nil
+	// and the first request panicked.
+	resolvedReq, err := validateProviderRequestTransform(path, providerName, req)
+	if err != nil {
+		return ProviderFile{}, err
+	}
 	if err := validateProviderHeaders(path, providerName, headers); err != nil {
+		return ProviderFile{}, err
+	}
+	if err := validateProviderResponse(path, providerName, response); err != nil {
 		return ProviderFile{}, err
 	}
 	resolvedUsage, err := validateProviderUsage(path, providerName, usage, resolved.usage)
@@ -192,7 +203,7 @@ func buildMergedProviderFile(path, providerName string, metadata ProviderMetadat
 		Metadata: metadata,
 		Routing:  routing,
 		Headers:  headers,
-		Request:  req,
+		Request:  resolvedReq,
 		Response: response,
 		Error:    perr,
 		Usage:    resolvedUsage,

--- a/onr-core/pkg/dslconfig/merged_file_resolve_test.go
+++ b/onr-core/pkg/dslconfig/merged_file_resolve_test.go
@@ -1,0 +1,120 @@
+package dslconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/r9s-ai/open-next-router/onr-core/pkg/dslmeta"
+)
+
+// The merged-file loader (ReloadFromFile, used for a single .conf entry point
+// with includes) and the per-file loader (ReloadFromDir) build ProviderFile
+// through different functions. Only the per-file one used to run the request
+// transform resolver, so a merged-file load returned validation rules whose
+// compiled path parts were nil and the first request panicked indexing them.
+//
+// These tests pin the resolved state for the merged path specifically. Loading
+// successfully is not enough to catch the regression: the gap only shows when
+// something reads the compiled fields.
+const mergedResolveProviderConf = `syntax "next-router/0.1";
+
+provider "merged-resolve" {
+  defaults {
+    upstream_config { base_url = "https://example.invalid"; }
+    response { resp_passthrough; }
+  }
+
+  match api = "images.generations" {
+    request {
+      req_required body "$.prompt";
+      req_len body "$.prompt" max=1500;
+      req_range body "$.n" min=1 max=9;
+      req_enum body "$.response_format" "url" "b64_json";
+    }
+    upstream { set_path "/v1/image_generation"; }
+  }
+}
+`
+
+func mustLoadMergedProviderFile(t *testing.T) ProviderFile {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "merged.conf")
+	if err := os.WriteFile(path, []byte(mergedResolveProviderConf), 0o600); err != nil {
+		t.Fatalf("write conf: %v", err)
+	}
+	reg := NewRegistry()
+	if _, err := reg.ReloadFromFile(path); err != nil {
+		t.Fatalf("ReloadFromFile: %v", err)
+	}
+	pf, ok := reg.GetProvider("merged-resolve")
+	if !ok {
+		t.Fatalf("provider not registered")
+	}
+	return pf
+}
+
+func TestMergedFileLoad_ResolvesRequestValidationRules(t *testing.T) {
+	pf := mustLoadMergedProviderFile(t)
+	meta := &dslmeta.Meta{API: "images.generations", IsStream: false}
+	tr, ok := pf.Request.Select(meta)
+	if !ok {
+		t.Fatalf("no request transform selected")
+	}
+	if len(tr.ValidationRules) != 4 {
+		t.Fatalf("rules got %d want 4", len(tr.ValidationRules))
+	}
+	for _, rule := range tr.ValidationRules {
+		// PathParts is what the runtime indexes into; a nil value is the
+		// unresolved state that panicked.
+		if len(rule.PathParts) == 0 {
+			t.Fatalf("rule %s %s has unresolved PathParts", rule.Op, rule.Path)
+		}
+	}
+}
+
+// req_enum additionally pre-parses its candidates; an unresolved rule would
+// accept nothing.
+func TestMergedFileLoad_ResolvesEnumCandidates(t *testing.T) {
+	pf := mustLoadMergedProviderFile(t)
+	meta := &dslmeta.Meta{API: "images.generations", IsStream: false}
+	tr, _ := pf.Request.Select(meta)
+	for _, rule := range tr.ValidationRules {
+		if rule.Op != ReqRuleEnum {
+			continue
+		}
+		if len(rule.LiteralValues) != 2 {
+			t.Fatalf("enum literals got %d want 2 (%#v)", len(rule.LiteralValues), rule.LiteralValues)
+		}
+		return
+	}
+	t.Fatal("no req_enum rule found")
+}
+
+// The merged path also skipped response validation entirely, so a response
+// directive the per-file path rejects loaded without complaint. An unsupported
+// sse_collect mode is one such case — unlike a resp_map mode, which both paths
+// deliberately tolerate and degrade to passthrough at runtime.
+func TestMergedFileLoad_ValidatesResponse(t *testing.T) {
+	const conf = `syntax "next-router/0.1";
+
+provider "merged-bad-response" {
+  defaults {
+    upstream_config { base_url = "https://example.invalid"; }
+  }
+
+  match api = "chat.completions" stream = false {
+    response { sse_collect definitely_not_a_real_mode; }
+    upstream { set_path "/v1/chat/completions"; }
+  }
+}
+`
+	path := filepath.Join(t.TempDir(), "merged.conf")
+	if err := os.WriteFile(path, []byte(conf), 0o600); err != nil {
+		t.Fatalf("write conf: %v", err)
+	}
+	reg := NewRegistry()
+	if _, err := reg.ReloadFromFile(path); err == nil {
+		t.Fatal("expected an unsupported sse_collect mode to be rejected on the merged path")
+	}
+}


### PR DESCRIPTION
关联 issue：edgefn/next-router-meta#542

## ⚠️ 现状：main 上的 DSL 图像渠道会 panic

`buildMergedProviderFile` 把解析后的 request transform 原样存进 `ProviderFile`，而其他每一段（usage / finish / balance / models）都过了各自的 resolver。resolver 正是把执行计划字段编译出来的地方——比如校验规则的 body 路径分段。

结果：从**单文件入口**（含 include 的 `.conf`）加载的配置，校验规则的 `PathParts` 是 nil，第一个请求就在 `lookupBody` 里 `parts[len(parts)-1]` 越界：

```
index out of range [-1]
```

**影响范围不止 minimax**。relay-config 里 minimax 和 **gemini** 的 `images.generations` 都有 `req_required` / `req_range`，两个都会 panic——而 gemini image（#59）已经合进 main 了。

## 为什么既有测试没发现

两条加载路径用的是不同的构建函数：

| 路径 | 构建函数 | 解析 Request？ |
|---|---|---|
| 目录加载（`ReloadFromDir`） | `validateAndBuildProviderFile` | ✅ |
| 单文件/合并加载（`ReloadFromFile`） | `buildMergedProviderFile` | ❌ |

现有测试**全部从目录加载**，而目录路径本来就是对的。relay 加载 relay-config 的 `nr.conf`（含 include 的单文件）走的是另一条。

更隐蔽的是：**加载本身从来没失败过**。配置校验全部通过，问题只在运行时读取那些未编译字段时才暴露，所以"能加载"这个信号具有误导性。

## 改动

- 补上 `validateProviderRequestTransform`，并把结果存入 `ProviderFile`
- 顺带补上合并路径同样跳过的 `validateProviderResponse`（不会 panic，但会让 per-file 路径拒绝的配置在这里静默通过）
- 三个回归测试，**专门走 `ReloadFromFile`**，断言的是**解析后的状态**而不是"加载成功"

## 验证

把修复撤掉后，新测试立刻复现未修复状态：

```
--- FAIL: TestMergedFileLoad_ResolvesRequestValidationRules
    rule required $.prompt has unresolved PathParts
--- FAIL: TestMergedFileLoad_ResolvesEnumCandidates
```

恢复后全绿。两个 module `go build` / `go test ./...` 全通过。

另外真实链路已验证：修复后完整 DSL 链路打通真实 MiniMax API（`api.minimax.io`），正常出图、参数校验按预期拒绝。

## 关于这个 PR 的由来

这两个提交原本推在 #66 的分支上，但当时 #66 已经合并，所以它们没进 main。这里基于最新 main 重新落地。

主题上它本来也该独立：这不是 minimax 特性的一部分，而是一个影响**所有**使用 `req_*` 校验指令的 DSL provider 的加载路径缺陷。

## 发布注意

relay 侧的 edgefn/next-router-relay#376 与 edgefn/next-router-relay-config#96 目前 CI 走同名分支解析 onr-core 源码，所以是绿的。但它们进入 release 链路时会按 `go.mod` 里的正式 tag 拉取——**必须确保本 PR 已合入 main 并发版**，否则线上会 panic。

🤖 Generated with [Claude Code](https://claude.com/claude-code)