### PR TITLE
fix(dslconfig): merge usage facts by billing identity

### DIFF
--- a/DSL_SYNTAX.md
+++ b/DSL_SYNTAX.md
@@ -1065,7 +1065,9 @@ metrics {
 - `event_optional=true` may be used together with `event="..."` when a provider sometimes omits SSE `event:` names.
 - `attr.ttl` distinguishes Anthropic cache-write tiers.
 - `attr.modality="text|image|audio|video"` may be used with `cache_read token` when the upstream reports real per-modality cached token counts. Relay uses this metadata to build provider cache detail fields such as `openai_cache` / `gemini_cache`.
-- Multiple `usage_fact` rules may share the same `dimension + unit`; all matched non-fallback rules are summed in declaration order.
+- Multiple `usage_fact` rules may share the same billing identity. A billing identity consists of the normalized `dimension + unit` and the complete `attr.*` set.
+- After fallback selection, matched rules with the same billing identity are emitted as one canonical fact whose quantity is their sum. Rules with different attributes, such as `attr.ttl="5m"` and `attr.ttl="1h"`, remain separate facts.
+- A merged fact keeps the extraction/debug metadata of the first matched rule in declaration order; its quantity may therefore include values read by later rules with the same billing identity.
 - `fallback=true` applies only when no more specific fact exists for the same `dimension + unit`.
 - `source` defaults to `usage` when `usage_root` is configured, otherwise it defaults to `response`.
 - `source` currently supports `usage`, `response`, `request`, and `derived`.

--- a/DSL_SYNTAX_CN.md
+++ b/DSL_SYNTAX_CN.md
@@ -1133,7 +1133,9 @@ metrics {
 - `event_optional=true` 可选，需要与 `event="..."` 一起使用，用于兼容“有时有 event、有时没有 event”的上游
 - `attr.ttl` 用于区分 Anthropic 的 `5m` / `1h` cache write
 - `attr.modality="text|image|audio|video"` 可用于 `cache_read token`，表示上游真实返回的分模态 cached token。Relay 会用它生成 `openai_cache` / `gemini_cache` 这类 provider cache detail 字段。
-- 同一 `dimension + unit` 可声明多条 `usage_fact`；所有命中的非 fallback 规则会按声明顺序累计求和
+- 多条 `usage_fact` 可以使用同一个计费身份。计费身份由规范化后的 `dimension + unit` 和完整的 `attr.*` 集合组成
+- 完成 fallback 选择后，计费身份相同的命中规则会输出为一条规范化事实，其数量为各规则数量之和。属性不同的规则仍保持为独立事实，例如 `attr.ttl="5m"` 与 `attr.ttl="1h"`
+- 合并后的事实保留声明顺序中第一条命中规则的提取和调试元数据，因此其数量可能还包含后续同计费身份规则读取到的值
 - `fallback=true` 用于在更具体的事实不存在时回退到总量字段
 - `source` 在配置了 `usage_root` 时默认是 `usage`，否则默认是 `response`
 - `source=usage` 表示从 `usage_root` 合并后的 usage 对象读取；`source=response` 表示从当前响应 JSON 提取；`source=request` 表示从当前请求 JSON 提取；`source=derived` 表示从 ONR 运行时派生出的聚合结果提取

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ The command validates the provider DSL before writing. If validation fails, no o
 
 ### Extract usage facts from a response
 
-`onr-usage-extract` is a local debugging utility for testing one explicit `usage_mode` against a response. It prints only the matched `usage_fact` items as a JSON array.
+`onr-usage-extract` is a local debugging utility for testing one explicit `usage_mode` against a response. It prints the matched canonical usage facts as a JSON array. Matched rules with the same normalized `dimension`, `unit`, and complete `attributes` set are combined into one fact whose quantity is their sum; facts with different attributes remain separate. A combined fact keeps the extraction metadata of the first matched rule.
 
 ```bash
 go run ./cmd/onr-usage-extract \

--- a/onr-core/pkg/dslconfig/stream_metrics_test.go
+++ b/onr-core/pkg/dslconfig/stream_metrics_test.go
@@ -389,7 +389,7 @@ func TestStreamMetricsAggregator_UsageRootFactsRunAtResult(t *testing.T) {
 	}
 }
 
-func TestStreamMetricsAggregator_UsageRootFinalDebugFactsKeepAdditiveOutputPaths(t *testing.T) {
+func TestStreamMetricsAggregator_UsageRootFinalDebugFactsMergeAdditiveOutputPaths(t *testing.T) {
 	meta := &dslmeta.Meta{API: "chat.completions", IsStream: true}
 	usageCfg := &UsageExtractConfig{
 		Mode: usageModeCustom,
@@ -435,8 +435,8 @@ func TestStreamMetricsAggregator_UsageRootFinalDebugFactsKeepAdditiveOutputPaths
 			outputFactTotal += fact.Quantity
 		}
 	}
-	if outputFactCount != 2 || outputFactTotal != 23 {
-		t.Fatalf("output debug facts count=%d total=%v want count=2 total=23; facts=%#v", outputFactCount, outputFactTotal, u.DebugFacts)
+	if outputFactCount != 1 || outputFactTotal != 23 {
+		t.Fatalf("output debug facts count=%d total=%v want count=1 total=23; facts=%#v", outputFactCount, outputFactTotal, u.DebugFacts)
 	}
 }
 

--- a/onr-core/pkg/dslconfig/usage_fact.go
+++ b/onr-core/pkg/dslconfig/usage_fact.go
@@ -208,6 +208,49 @@ func evaluateUsageFactConfigGroupsWithEvent(event string, reqRoot, respRoot, usa
 	return out
 }
 
+// mergeUsageFactEvals sums matched facts that share the same billing identity.
+// Attributes are part of the identity because facts such as cache TTL and
+// modality can use different prices even when their dimension and unit match.
+func mergeUsageFactEvals(evals []usageFactEval) []usageFactEval {
+	if len(evals) < 2 {
+		return evals
+	}
+
+	merged := make([]usageFactEval, 0, len(evals))
+	indexByKey := make(map[string]int, len(evals))
+	for _, eval := range evals {
+		if !eval.matched {
+			continue
+		}
+		key := usageFactEvalMergeKey(eval.cfg)
+		if idx, ok := indexByKey[key]; ok {
+			merged[idx].quantity += eval.quantity
+			continue
+		}
+		indexByKey[key] = len(merged)
+		merged = append(merged, eval)
+	}
+	return merged
+}
+
+func usageFactEvalMergeKey(fact usageFactConfig) string {
+	key := normalizeUsageFactKey(fact.Dimension, fact.Unit)
+	parts := []string{key.Dimension, key.Unit}
+	if len(fact.Attrs) == 0 {
+		return strings.Join(parts, "\x1f")
+	}
+
+	attrKeys := make([]string, 0, len(fact.Attrs))
+	for key := range fact.Attrs {
+		attrKeys = append(attrKeys, key)
+	}
+	sort.Strings(attrKeys)
+	for _, key := range attrKeys {
+		parts = append(parts, strings.TrimSpace(key)+"="+strings.TrimSpace(fact.Attrs[key]))
+	}
+	return strings.Join(parts, "\x1f")
+}
+
 func filterUsageFactConfigForStream(cfg UsageExtractConfig, keep func(usageFactConfig) bool) UsageExtractConfig {
 	if len(cfg.facts) == 0 {
 		return cfg
@@ -466,6 +509,7 @@ func extractCustomUsageWithEvent(event string, reqRoot, respRoot, derivedRoot ma
 	evals := make([]usageFactEval, 0, len(cfg.facts))
 	usageRoot := extractUsageRootWithEvent(event, respRoot, cfg.usageRoots)
 	evals = append(evals, evaluateUsageFactConfigGroupsWithEvent(event, reqRoot, respRoot, usageRoot, derivedRoot, len(cfg.usageRoots) > 0, cfg.factGroups, len(cfg.facts))...)
+	evals = mergeUsageFactEvals(evals)
 
 	usage, cachedTokens := projectUsageFromFacts(evals, len(cfg.usageRoots) > 0)
 	if cfg.TotalTokensExpr != nil {
@@ -479,6 +523,7 @@ func extractCustomUsageWithEvent(event string, reqRoot, respRoot, derivedRoot ma
 func extractCustomUsageFromMergedUsageRoot(reqRoot, usageRoot, derivedRoot map[string]any, cfg UsageExtractConfig) (*Usage, int) {
 	evals := make([]usageFactEval, 0, len(cfg.facts))
 	evals = append(evals, evaluateUsageFactConfigGroupsWithEvent("", reqRoot, nil, usageRoot, derivedRoot, true, cfg.factGroups, len(cfg.facts))...)
+	evals = mergeUsageFactEvals(evals)
 
 	usage, cachedTokens := projectUsageFromFacts(evals, true)
 	// Stream final-stage facts already read from the merged usage root. Total is

--- a/onr-core/pkg/dslconfig/usage_fact_test.go
+++ b/onr-core/pkg/dslconfig/usage_fact_test.go
@@ -3,6 +3,8 @@ package dslconfig
 import (
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -1285,7 +1287,7 @@ func TestExtractUsage_CustomLegacyOverrideDoesNotDoubleCount(t *testing.T) {
 	}
 }
 
-func TestExtractUsage_UsageFactSameDimensionDeclarationOrder(t *testing.T) {
+func TestExtractUsage_UsageFactSameDimensionMerged(t *testing.T) {
 	cfg := UsageExtractConfig{
 		Mode: usageModeCustom,
 		facts: []usageFactConfig{
@@ -1321,26 +1323,198 @@ func TestExtractUsage_UsageFactSameDimensionDeclarationOrder(t *testing.T) {
 			inputFacts = append(inputFacts, fact)
 		}
 	}
-	if got, want := len(inputFacts), 2; got != want {
+	if got, want := len(inputFacts), 1; got != want {
 		t.Fatalf("input debug facts len got %d, want %d", got, want)
 	}
 	if got, want := inputFacts[0].Path, "$.usage.first_input_tokens"; got != want {
 		t.Fatalf("first input fact path got %q, want %q", got, want)
 	}
-	if got, want := inputFacts[0].Quantity, 3.0; got != want {
+	if got, want := inputFacts[0].Quantity, 7.0; got != want {
 		t.Fatalf("first input fact quantity got %v, want %v", got, want)
-	}
-	if got, want := inputFacts[1].Path, "$.usage.second_input_tokens"; got != want {
-		t.Fatalf("second input fact path got %q, want %q", got, want)
-	}
-	if got, want := inputFacts[1].Quantity, 4.0; got != want {
-		t.Fatalf("second input fact quantity got %v, want %v", got, want)
 	}
 	for _, fact := range inputFacts {
 		if fact.Fallback {
 			t.Fatalf("unexpected fallback fact in matched input facts: %+v", fact)
 		}
 	}
+}
+
+func TestExtractUsage_UsageFactSameDimensionKeepsDifferentAttributes(t *testing.T) {
+	cfg := UsageExtractConfig{
+		Mode: usageModeCustom,
+		facts: []usageFactConfig{
+			{Dimension: "cache_write", Unit: "token", Path: "$.usage.cache_5m", Attrs: map[string]string{"ttl": "5m"}},
+			{Dimension: "cache_write", Unit: "token", Path: "$.usage.cache_1h", Attrs: map[string]string{"ttl": "1h"}},
+		},
+	}
+
+	body := []byte(`{
+	  "usage": {
+	    "cache_5m": 3,
+	    "cache_1h": 4
+	  }
+	}`)
+
+	usage, _, err := ExtractUsage(&dslmeta.Meta{}, &cfg, body)
+	if err != nil {
+		t.Fatalf("ExtractUsage: %v", err)
+	}
+	if usage == nil {
+		t.Fatalf("expected usage")
+	}
+	if got, want := len(usage.DebugFacts), 2; got != want {
+		t.Fatalf("DebugFacts len got %d, want %d: %#v", got, want, usage.DebugFacts)
+	}
+
+	quantities := make(map[string]float64, len(usage.DebugFacts))
+	for _, fact := range usage.DebugFacts {
+		quantities[fact.Attributes["ttl"]] = fact.Quantity
+	}
+	if got, want := quantities["5m"], 3.0; got != want {
+		t.Fatalf("5m cache quantity got %v, want %v", got, want)
+	}
+	if got, want := quantities["1h"], 4.0; got != want {
+		t.Fatalf("1h cache quantity got %v, want %v", got, want)
+	}
+}
+
+func TestExtractUsage_AllCanonicalUsageFactsMergeSameIdentity(t *testing.T) {
+	for _, key := range canonicalUsageFactTestKeys() {
+		t.Run(key.Dimension+"_"+key.Unit, func(t *testing.T) {
+			cfg := UsageExtractConfig{
+				Mode: usageModeCustom,
+				facts: []usageFactConfig{
+					{Dimension: key.Dimension, Unit: key.Unit, Path: "$.first"},
+					{Dimension: key.Dimension, Unit: key.Unit, Path: "$.second"},
+				},
+			}
+
+			usage, _, err := ExtractUsageObject(&dslmeta.Meta{}, &cfg, map[string]any{
+				"first":  2,
+				"second": 3,
+			})
+			if err != nil {
+				t.Fatalf("ExtractUsageObject: %v", err)
+			}
+			if usage == nil {
+				t.Fatal("expected usage")
+			}
+			if got, want := len(usage.DebugFacts), 1; got != want {
+				t.Fatalf("DebugFacts len got %d, want %d: %#v", got, want, usage.DebugFacts)
+			}
+			fact := usage.DebugFacts[0]
+			if fact.Dimension != key.Dimension || fact.Unit != key.Unit || fact.Quantity != 5 {
+				t.Fatalf("merged fact got %#v, want dimension=%q unit=%q quantity=5", fact, key.Dimension, key.Unit)
+			}
+		})
+	}
+}
+
+func TestExtractUsage_AllCanonicalUsageFactsKeepDifferentAttributes(t *testing.T) {
+	for _, key := range canonicalUsageFactTestKeys() {
+		t.Run(key.Dimension+"_"+key.Unit, func(t *testing.T) {
+			cfg := UsageExtractConfig{
+				Mode: usageModeCustom,
+				facts: []usageFactConfig{
+					{
+						Dimension: key.Dimension,
+						Unit:      key.Unit,
+						Path:      "$.first",
+						Attrs:     map[string]string{"variant": "first"},
+					},
+					{
+						Dimension: key.Dimension,
+						Unit:      key.Unit,
+						Path:      "$.second",
+						Attrs:     map[string]string{"variant": "second"},
+					},
+				},
+			}
+
+			usage, _, err := ExtractUsageObject(&dslmeta.Meta{}, &cfg, map[string]any{
+				"first":  2,
+				"second": 3,
+			})
+			if err != nil {
+				t.Fatalf("ExtractUsageObject: %v", err)
+			}
+			if usage == nil {
+				t.Fatal("expected usage")
+			}
+			if got, want := len(usage.DebugFacts), 2; got != want {
+				t.Fatalf("DebugFacts len got %d, want %d: %#v", got, want, usage.DebugFacts)
+			}
+
+			quantities := make(map[string]float64, len(usage.DebugFacts))
+			for _, fact := range usage.DebugFacts {
+				if fact.Dimension != key.Dimension || fact.Unit != key.Unit {
+					t.Fatalf("unexpected fact identity: %#v", fact)
+				}
+				quantities[fact.Attributes["variant"]] = fact.Quantity
+			}
+			if quantities["first"] != 2 || quantities["second"] != 3 {
+				t.Fatalf("attribute quantities got %#v, want first=2 second=3", quantities)
+			}
+		})
+	}
+}
+
+func TestExtractUsage_AllCanonicalUsageFactsRemainIndependent(t *testing.T) {
+	keys := canonicalUsageFactTestKeys()
+	facts := make([]usageFactConfig, 0, len(keys))
+	root := make(map[string]any, len(keys))
+	want := make(map[usageFactKey]float64, len(keys))
+	for i, key := range keys {
+		field := "value_" + strconv.Itoa(i)
+		quantity := float64(i + 1)
+		facts = append(facts, usageFactConfig{
+			Dimension: key.Dimension,
+			Unit:      key.Unit,
+			Path:      "$." + field,
+		})
+		root[field] = quantity
+		want[key] = quantity
+	}
+
+	cfg := UsageExtractConfig{Mode: usageModeCustom, facts: facts}
+	usage, _, err := ExtractUsageObject(&dslmeta.Meta{}, &cfg, root)
+	if err != nil {
+		t.Fatalf("ExtractUsageObject: %v", err)
+	}
+	if usage == nil {
+		t.Fatal("expected usage")
+	}
+	if got, wantCount := len(usage.DebugFacts), len(keys); got != wantCount {
+		t.Fatalf("DebugFacts len got %d, want %d: %#v", got, wantCount, usage.DebugFacts)
+	}
+	for _, fact := range usage.DebugFacts {
+		key := normalizeUsageFactKey(fact.Dimension, fact.Unit)
+		quantity, ok := want[key]
+		if !ok {
+			t.Fatalf("unexpected fact identity: %#v", fact)
+		}
+		if fact.Quantity != quantity {
+			t.Fatalf("fact %s/%s quantity got %v, want %v", fact.Dimension, fact.Unit, fact.Quantity, quantity)
+		}
+		delete(want, key)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing canonical facts: %#v", want)
+	}
+}
+
+func canonicalUsageFactTestKeys() []usageFactKey {
+	keys := make([]usageFactKey, 0, len(defaultUsageDimensionRegistry.allowed))
+	for key := range defaultUsageDimensionRegistry.allowed {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].Dimension != keys[j].Dimension {
+			return keys[i].Dimension < keys[j].Dimension
+		}
+		return keys[i].Unit < keys[j].Unit
+	})
+	return keys
 }
 
 func TestExtractUsage_UsageFactRequestSource(t *testing.T) {

--- a/onr-core/pkg/usageextract/cli_test.go
+++ b/onr-core/pkg/usageextract/cli_test.go
@@ -40,9 +40,7 @@ func TestRunCLIExtractsFactsFromInlineUsageMode(t *testing.T) {
 	if !strings.Contains(stdout, "\n  {") {
 		t.Fatalf("expected formatted JSON output, got %q", stdout)
 	}
-	assertFact(t, facts, "input", "token", 10, nil)
-	assertFact(t, facts, "input", "token", 2, nil)
-	assertFact(t, facts, "input", "token", 3, nil)
+	assertFact(t, facts, "input", "token", 15, nil)
 	assertFact(t, facts, "output", "token", 4, nil)
 	assertFact(t, facts, "cache_read", "token", 2, nil)
 	assertFact(t, facts, "cache_write", "token", 3, map[string]string{"ttl": "5m"})


### PR DESCRIPTION
## PR Title:
fix(dslconfig): merge usage facts by billing identity
## Description

Merge matched usage facts that share the same billing identity into a single canonical fact.

A billing identity consists of the normalized `dimension`, `unit`, and complete attribute set. Quantities from matching facts with the same identity are summed, while facts with different attributes—such as different cache TTLs or modalities—remain separate.

This change applies consistently to regular extraction and stream final-stage extraction. It also updates `onr-usage-extract` expectations and documents the merging semantics in `DSL_SYNTAX.md` and `README.md`.



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

The full `onr-core` test suite was run:

```bash
go test -count=1 ./onr-core/...
```

Test coverage includes:

- Merging facts with the same dimension, unit, and attributes
- Keeping facts with different attributes separate
- Keeping different canonical billing identities independent
- Stream final-stage usage aggregation
- `onr-usage-extract` CLI output

- [ ] Manual test
- [x] Unit test
- [ ] Integration test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules (N/A)
```

