### PR TITLE
fix(apitransform): align Gemini chat response metadata

### DIFF
--- a/onr-core/pkg/apitransform/gemini_openai.go
+++ b/onr-core/pkg/apitransform/gemini_openai.go
@@ -378,7 +378,7 @@ func MapGeminiGenerateContentToOpenAIChatCompletionsResponseObject(root apitypes
 		choices = append(choices, apitypes.JSONObject{
 			"index":         idx,
 			"message":       msg,
-			"finish_reason": strings.TrimSpace(jsonutil.CoerceString(cand["finishReason"])),
+			"finish_reason": mapGeminiFinishToOpenAI(jsonutil.CoerceString(cand["finishReason"]), len(toolCalls) > 0),
 		})
 	}
 
@@ -454,21 +454,26 @@ func mapGeminiUsageToOpenAI(raw map[string]any) (apitypes.JSONObject, error) {
 		return nil, err
 	}
 	promptTokens := usage.PromptTokenCount
-	completionTokens := usage.CandidatesTokenCount
+	completionTokens := 0
 	totalTokens := usage.TotalTokenCount
-	if totalTokens <= 0 {
+	cachedTokens := usage.CachedContentTokenCount
+	if totalTokens > 0 {
+		completionTokens = totalTokens - promptTokens
+	} else {
+		completionTokens = usage.CandidatesTokenCount + usage.ThoughtsTokenCount
 		totalTokens = promptTokens + completionTokens
 	}
 	if completionTokens <= 0 {
-		completionTokens = totalTokens - promptTokens
-	}
-	if completionTokens < 0 {
 		completionTokens = 0
 	}
+
 	out := apitypes.JSONObject{
 		"prompt_tokens":     usage.PromptTokenCount,
 		"completion_tokens": completionTokens,
 		"total_tokens":      totalTokens,
+		"prompt_tokens_details": apitypes.JSONObject{
+			"cached_tokens": cachedTokens,
+		},
 	}
 	if usage.ThoughtsTokenCount > 0 {
 		out["completion_tokens_details"] = apitypes.JSONObject{
@@ -591,5 +596,24 @@ func mapOpenAIFinishToGemini(finish string) string {
 		return "SAFETY"
 	default:
 		return "STOP"
+	}
+}
+
+func mapGeminiFinishToOpenAI(finish string, hasToolCalls bool) string {
+	normalized := strings.ToUpper(strings.TrimSpace(finish))
+	if normalized == "" {
+		return ""
+	}
+	if hasToolCalls {
+		return "tool_calls"
+	}
+	switch normalized {
+	case "MAX_TOKENS":
+		return "length"
+	case "SAFETY", "RECITATION", "LANGUAGE", "BLOCKLIST", "PROHIBITED_CONTENT", "SPII",
+		"IMAGE_SAFETY", "IMAGE_PROHIBITED_CONTENT", "IMAGE_RECITATION":
+		return finishContentFilter
+	default:
+		return "stop"
 	}
 }

--- a/onr-core/pkg/apitransform/gemini_openai_test.go
+++ b/onr-core/pkg/apitransform/gemini_openai_test.go
@@ -130,3 +130,32 @@ func TestMapGeminiGenerateContentToOpenAIChatCompletionsResponse_UsageFallbackWi
 		t.Fatalf("unexpected mapped output: %s", s)
 	}
 }
+
+func TestMapGeminiFinishToOpenAI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		finish       string
+		hasToolCalls bool
+		want         string
+	}{
+		{name: "empty", want: ""},
+		{name: "stop", finish: "STOP", want: "stop"},
+		{name: "max tokens", finish: "MAX_TOKENS", want: "length"},
+		{name: "safety", finish: "SAFETY", want: "content_filter"},
+		{name: "image safety", finish: "IMAGE_SAFETY", want: "content_filter"},
+		{name: "unknown", finish: "OTHER", want: "stop"},
+		{name: "unfinished tool call", hasToolCalls: true, want: ""},
+		{name: "tool calls", finish: "STOP", hasToolCalls: true, want: "tool_calls"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := mapGeminiFinishToOpenAI(tt.finish, tt.hasToolCalls); got != tt.want {
+				t.Fatalf("mapGeminiFinishToOpenAI(%q, %v)=%q want=%q", tt.finish, tt.hasToolCalls, got, tt.want)
+			}
+		})
+	}
+}

--- a/onr-core/pkg/apitransform/gemini_sse_to_openai_chat.go
+++ b/onr-core/pkg/apitransform/gemini_sse_to_openai_chat.go
@@ -95,7 +95,7 @@ func (s *geminiSSEToChatState) handlePayload(payload []byte) error {
 				if len(toolCalls) > 0 {
 					delta["tool_calls"] = toolCalls
 				}
-				finish := strings.TrimSpace(cand.FinishReason)
+				finish := mapGeminiFinishToOpenAI(cand.FinishReason, len(toolCalls) > 0)
 				if len(delta) == 1 && finish == "" {
 					continue
 				}
@@ -187,14 +187,25 @@ func geminiUsageToChatChunkUsage(usage *apitypes.UsageMetadata) apitypes.JSONObj
 	if usage == nil {
 		return nil
 	}
-	completionTokens := usage.TotalTokenCount - usage.PromptTokenCount
+	promptTokens := usage.PromptTokenCount
+	totalTokens := usage.TotalTokenCount
+	var completionTokens int
+	if totalTokens > 0 {
+		completionTokens = totalTokens - promptTokens
+	} else {
+		completionTokens = usage.CandidatesTokenCount + usage.ThoughtsTokenCount
+		totalTokens = promptTokens + completionTokens
+	}
 	if completionTokens < 0 {
 		completionTokens = 0
 	}
 	out := apitypes.JSONObject{
 		"prompt_tokens":     usage.PromptTokenCount,
 		"completion_tokens": completionTokens,
-		"total_tokens":      usage.TotalTokenCount,
+		"total_tokens":      totalTokens,
+	}
+	out["prompt_tokens_details"] = apitypes.JSONObject{
+		"cached_tokens": usage.CachedContentTokenCount,
 	}
 	out["completion_tokens_details"] = apitypes.JSONObject{
 		"reasoning_tokens": usage.ThoughtsTokenCount,

--- a/onr-core/pkg/apitransform/gemini_sse_to_openai_chat_test.go
+++ b/onr-core/pkg/apitransform/gemini_sse_to_openai_chat_test.go
@@ -16,7 +16,7 @@ func TestTransformGeminiSSEToOpenAIChatCompletionsSSE_Basic(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	s := out.String()
-	if !containsAll(s, `"chat.completion.chunk"`, `"role":"assistant"`, `"content":"Hi"`, `"finish_reason":"STOP"`) {
+	if !containsAll(s, `"chat.completion.chunk"`, `"role":"assistant"`, `"content":"Hi"`, `"finish_reason":"stop"`) {
 		t.Fatalf("unexpected output: %s", s)
 	}
 	if !containsAll(s, `"usage"`, `"prompt_tokens":1`, `"completion_tokens":2`, `"total_tokens":3`) {

--- a/onr-core/pkg/apitransform/response_by_mode_test.go
+++ b/onr-core/pkg/apitransform/response_by_mode_test.go
@@ -189,7 +189,7 @@ func TestMapResponseBodyByMode_GeminiToOpenAIChat(t *testing.T) {
 		`"object":"chat.completion"`,
 		`"model":"gemini-2.5-pro"`,
 		`"content":"hello"`,
-		`"finish_reason":"STOP"`,
+		`"finish_reason":"tool_calls"`,
 		`"name":"lookup_weather"`,
 		`"name":"emit_media"`,
 		`"prompt_tokens":11`,

--- a/onr/internal/proxy/e2e_mock_test.go
+++ b/onr/internal/proxy/e2e_mock_test.go
@@ -429,7 +429,7 @@ func TestE2EMock_ChatCompletions_Gemini_Stream(t *testing.T) {
 		`"object":"chat.completion.chunk"`,
 		`"role":"assistant"`,
 		`"content":"Hi"`,
-		`"finish_reason":"STOP"`,
+		`"finish_reason":"stop"`,
 		`"total_tokens":3`,
 		"data: [DONE]",
 	) {

--- a/onr/internal/proxy/testdata/golden/gemini_stream_openai_chat.sse
+++ b/onr/internal/proxy/testdata/golden/gemini_stream_openai_chat.sse
@@ -1,5 +1,5 @@
 data: {"choices":[{"delta":{"content":"Hi","role":"assistant"},"index":0}],"created":0,"id":"chatcmpl_mock","model":"gemini-2.0-flash","object":"chat.completion.chunk"}
 
-data: {"choices":[{"delta":{"content":"!","role":"assistant"},"finish_reason":"STOP","index":0}],"created":0,"id":"chatcmpl_mock","model":"gemini-2.0-flash","object":"chat.completion.chunk","usage":{"completion_tokens":2,"completion_tokens_details":{"reasoning_tokens":0},"prompt_tokens":1,"total_tokens":3}}
+data: {"choices":[{"delta":{"content":"!","role":"assistant"},"finish_reason":"stop","index":0}],"created":0,"id":"chatcmpl_mock","model":"gemini-2.0-flash","object":"chat.completion.chunk","usage":{"completion_tokens":2,"completion_tokens_details":{"reasoning_tokens":0},"prompt_tokens":1,"prompt_tokens_details":{"cached_tokens":0},"total_tokens":3}}
 
 data: [DONE]


### PR DESCRIPTION
## Description

Align Gemini streaming and non-streaming responses with the OpenAI Chat Completions format.

- Map Gemini usage and cached tokens to OpenAI usage fields
- Normalize Gemini finish reasons to OpenAI-compatible values
- Keep streaming and non-streaming response behavior consistent
- Update related unit tests and E2E golden output

Fixes #<issue-number>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

- `go test ./...`

- [ ] Manual test
- [x] Unit test
- [x] Integration test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules