### PR TITLE
feat(dslconfig): add provider upstream request ID observability

### DIFF
--- a/onr-core/pkg/dslconfig/core_registry.go
+++ b/onr-core/pkg/dslconfig/core_registry.go
@@ -11,19 +11,20 @@ import (
 )
 
 type ProviderFile struct {
-	Name     string
-	Path     string
-	Content  string
-	Metadata ProviderMetadata
-	Routing  ProviderRouting
-	Headers  ProviderHeaders
-	Request  ProviderRequestTransform
-	Response ProviderResponse
-	Error    ProviderError
-	Usage    ProviderUsage
-	Finish   ProviderFinishReason
-	Balance  ProviderBalance
-	Models   ProviderModels
+	Name          string
+	Path          string
+	Content       string
+	Metadata      ProviderMetadata
+	Routing       ProviderRouting
+	Headers       ProviderHeaders
+	Request       ProviderRequestTransform
+	Response      ProviderResponse
+	Error         ProviderError
+	Usage         ProviderUsage
+	Finish        ProviderFinishReason
+	Balance       ProviderBalance
+	Models        ProviderModels
+	Observability ProviderObservability
 }
 
 type Registry struct {

--- a/onr-core/pkg/dslconfig/core_registry_file.go
+++ b/onr-core/pkg/dslconfig/core_registry_file.go
@@ -133,7 +133,7 @@ func parseProvidersFromMergedFile(path string, content string, inherited modeReg
 			if lb.kind != tokLBrace {
 				return nil, nil, s.errAt(lb, "expected '{' after provider name")
 			}
-			routing, headers, req, response, perr, usage, finish, balance, models, err := parseProviderBody(s)
+			routing, headers, req, response, perr, usage, finish, balance, models, observability, err := parseProviderBody(s)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -141,7 +141,7 @@ func parseProvidersFromMergedFile(path string, content string, inherited modeReg
 			if err != nil {
 				return nil, nil, err
 			}
-			pf, err := buildMergedProviderFile(path, providerName, metadata, routing, headers, req, response, perr, usage, finish, balance, models, resolved)
+			pf, err := buildMergedProviderFile(path, providerName, metadata, routing, headers, req, response, perr, usage, finish, balance, models, observability, resolved)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -156,7 +156,7 @@ func parseProvidersFromMergedFile(path string, content string, inherited modeReg
 	return next, loaded, nil
 }
 
-func buildMergedProviderFile(path, providerName string, metadata ProviderMetadata, routing ProviderRouting, headers ProviderHeaders, req ProviderRequestTransform, response ProviderResponse, perr ProviderError, usage ProviderUsage, finish ProviderFinishReason, balance ProviderBalance, models ProviderModels, resolved modeRegistryState) (ProviderFile, error) {
+func buildMergedProviderFile(path, providerName string, metadata ProviderMetadata, routing ProviderRouting, headers ProviderHeaders, req ProviderRequestTransform, response ProviderResponse, perr ProviderError, usage ProviderUsage, finish ProviderFinishReason, balance ProviderBalance, models ProviderModels, observability ProviderObservability, resolved modeRegistryState) (ProviderFile, error) {
 	if err := validateProviderBaseURL(path, providerName, routing); err != nil {
 		return ProviderFile{}, err
 	}
@@ -197,18 +197,19 @@ func buildMergedProviderFile(path, providerName string, metadata ProviderMetadat
 		return ProviderFile{}, err
 	}
 	return ProviderFile{
-		Name:     providerName,
-		Path:     path,
-		Content:  "",
-		Metadata: metadata,
-		Routing:  routing,
-		Headers:  headers,
-		Request:  resolvedReq,
-		Response: response,
-		Error:    perr,
-		Usage:    resolvedUsage,
-		Finish:   resolvedFinish,
-		Balance:  resolvedBalance,
-		Models:   resolvedModels,
+		Name:          providerName,
+		Path:          path,
+		Content:       "",
+		Metadata:      metadata,
+		Routing:       routing,
+		Headers:       headers,
+		Request:       resolvedReq,
+		Response:      response,
+		Error:         perr,
+		Usage:         resolvedUsage,
+		Finish:        resolvedFinish,
+		Balance:       resolvedBalance,
+		Models:        resolvedModels,
+		Observability: observability,
 	}, nil
 }

--- a/onr-core/pkg/dslconfig/observability.go
+++ b/onr-core/pkg/dslconfig/observability.go
@@ -1,0 +1,11 @@
+package dslconfig
+
+// ProviderObservability contains provider-scoped observation rules.
+type ProviderObservability struct {
+	UpstreamRequestID *UpstreamRequestIDRule
+}
+
+// UpstreamRequestIDRule lists upstream response headers in lookup priority order.
+type UpstreamRequestIDRule struct {
+	Headers []string
+}

--- a/onr-core/pkg/dslconfig/observability_test.go
+++ b/onr-core/pkg/dslconfig/observability_test.go
@@ -1,0 +1,87 @@
+package dslconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeObservabilityProvider(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "example.conf")
+	content := `provider "example" {
+	defaults { upstream_config { base_url = "https://example.com"; } }
+` + body + "\n}\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestValidateProviderFile_ObservabilityUpstreamRequestID(t *testing.T) {
+	path := writeObservabilityProvider(t, `
+	observability {
+		upstream_request_id "x-request-id" "OpenAI-Request-ID";
+	}
+`)
+	pf, err := ValidateProviderFile(path)
+	if err != nil {
+		t.Fatalf("ValidateProviderFile: %v", err)
+	}
+	if pf.Observability.UpstreamRequestID == nil {
+		t.Fatal("expected upstream request ID rule")
+	}
+	want := []string{"x-request-id", "OpenAI-Request-ID"}
+	if got := pf.Observability.UpstreamRequestID.Headers; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("headers=%v want=%v", got, want)
+	}
+}
+
+func TestValidateProviderFile_ObservabilityRejectsInvalidRules(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"missing semicolon", `observability { upstream_request_id "x-request-id" }`, "expected ';' after upstream_request_id"},
+		{"invalid header", `observability { upstream_request_id "bad header"; }`, "invalid upstream request ID header name"},
+		{"duplicate header", `observability { upstream_request_id "X-Request-ID" "x-request-id"; }`, "duplicate upstream request ID header"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ValidateProviderFile(writeObservabilityProvider(t, tt.body))
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error=%v want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateProviderFile_ObservabilityAllowsEmptyRule(t *testing.T) {
+	pf, err := ValidateProviderFile(writeObservabilityProvider(t, `
+	observability {
+		upstream_request_id;
+	}
+`))
+	if err != nil {
+		t.Fatalf("ValidateProviderFile: %v", err)
+	}
+	if pf.Observability.UpstreamRequestID == nil {
+		t.Fatal("expected explicitly configured empty rule")
+	}
+	if len(pf.Observability.UpstreamRequestID.Headers) != 0 {
+		t.Fatalf("headers=%v want empty", pf.Observability.UpstreamRequestID.Headers)
+	}
+}
+
+func TestValidateProviderFile_ObservabilityMissingIsUnset(t *testing.T) {
+	pf, err := ValidateProviderFile(writeObservabilityProvider(t, ""))
+	if err != nil {
+		t.Fatalf("ValidateProviderFile: %v", err)
+	}
+	if pf.Observability.UpstreamRequestID != nil {
+		t.Fatalf("expected unset rule, got %#v", pf.Observability.UpstreamRequestID)
+	}
+}

--- a/onr-core/pkg/dslconfig/parse_observability.go
+++ b/onr-core/pkg/dslconfig/parse_observability.go
@@ -1,0 +1,77 @@
+package dslconfig
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+func parseObservabilityBlock(s *scanner) (ProviderObservability, error) {
+	var out ProviderObservability
+	lb := s.nextNonTrivia()
+	if lb.kind != tokLBrace {
+		return out, s.errAt(lb, "expected '{' after observability")
+	}
+	for {
+		tok := s.nextNonTrivia()
+		switch tok.kind {
+		case tokEOF:
+			return ProviderObservability{}, s.errAt(tok, "unexpected EOF in observability block")
+		case tokRBrace:
+			return out, nil
+		case tokIdent:
+			if tok.text != "upstream_request_id" {
+				return ProviderObservability{}, s.errAt(tok, fmt.Sprintf("unknown observability directive %q", tok.text))
+			}
+			headers, err := parseUpstreamRequestIDHeaders(s)
+			if err != nil {
+				return ProviderObservability{}, err
+			}
+			out.UpstreamRequestID = &UpstreamRequestIDRule{Headers: headers}
+		default:
+			return ProviderObservability{}, s.errAt(tok, "unexpected token in observability block")
+		}
+	}
+}
+
+func parseUpstreamRequestIDHeaders(s *scanner) ([]string, error) {
+	const maxHeaders = 16
+	headers := make([]string, 0, 2)
+	seen := map[string]struct{}{}
+	for {
+		tok := s.nextNonTrivia()
+		switch tok.kind {
+		case tokString:
+			name := strings.TrimSpace(unquoteString(tok.text))
+			if name == "" || !validHeaderFieldName(name) {
+				return nil, s.errAt(tok, fmt.Sprintf("invalid upstream request ID header name %q", name))
+			}
+			key := strings.ToLower(name)
+			if _, ok := seen[key]; ok {
+				return nil, s.errAt(tok, fmt.Sprintf("duplicate upstream request ID header %q", name))
+			}
+			seen[key] = struct{}{}
+			headers = append(headers, name)
+			if len(headers) > maxHeaders {
+				return nil, s.errAt(tok, fmt.Sprintf("too many upstream request ID headers (maximum %d)", maxHeaders))
+			}
+		case tokSemicolon:
+			return headers, nil
+		case tokEOF:
+			return nil, s.errAt(tok, "expected ';' after upstream_request_id")
+		case tokRBrace:
+			return nil, s.errAt(tok, "expected ';' after upstream_request_id")
+		default:
+			return nil, s.errAt(tok, "upstream_request_id expects string header names followed by ';'")
+		}
+	}
+}
+
+func validHeaderFieldName(name string) bool {
+	for _, r := range name {
+		if r <= 0x20 || r >= 0x7f || !unicode.IsPrint(r) || strings.ContainsRune("()<>@,;:\\\"/[]?={} \t", r) {
+			return false
+		}
+	}
+	return true
+}

--- a/onr-core/pkg/dslconfig/parse_provider.go
+++ b/onr-core/pkg/dslconfig/parse_provider.go
@@ -9,6 +9,11 @@ import (
 const providerKeyword = "provider"
 
 func parseProviderConfig(path string, content string) (ProviderRouting, ProviderHeaders, ProviderRequestTransform, ProviderResponse, ProviderError, ProviderUsage, ProviderFinishReason, ProviderBalance, ProviderModels, error) {
+	r, h, rq, resp, e, u, fr, bq, mq, _, err := parseProviderConfigWithObservability(path, content)
+	return r, h, rq, resp, e, u, fr, bq, mq, err
+}
+
+func parseProviderConfigWithObservability(path string, content string) (ProviderRouting, ProviderHeaders, ProviderRequestTransform, ProviderResponse, ProviderError, ProviderUsage, ProviderFinishReason, ProviderBalance, ProviderModels, ProviderObservability, error) {
 	s := newScanner(path, content)
 	var routing ProviderRouting
 	var headers ProviderHeaders
@@ -19,6 +24,7 @@ func parseProviderConfig(path string, content string) (ProviderRouting, Provider
 	var finish ProviderFinishReason
 	var balance ProviderBalance
 	var models ProviderModels
+	var observability ProviderObservability
 	for {
 		tok := s.nextNonTrivia()
 		if tok.kind == tokEOF {
@@ -27,15 +33,15 @@ func parseProviderConfig(path string, content string) (ProviderRouting, Provider
 		if tok.kind == tokIdent && tok.text == providerKeyword {
 			nameTok := s.nextNonTrivia()
 			if nameTok.kind != tokString {
-				return ProviderRouting{}, ProviderHeaders{}, ProviderRequestTransform{}, ProviderResponse{}, ProviderError{}, ProviderUsage{}, ProviderFinishReason{}, ProviderBalance{}, ProviderModels{}, s.errAt(nameTok, "expected provider name string literal")
+				return ProviderRouting{}, ProviderHeaders{}, ProviderRequestTransform{}, ProviderResponse{}, ProviderError{}, ProviderUsage{}, ProviderFinishReason{}, ProviderBalance{}, ProviderModels{}, ProviderObservability{}, s.errAt(nameTok, "expected provider name string literal")
 			}
 			lb := s.nextNonTrivia()
 			if lb.kind != tokLBrace {
-				return ProviderRouting{}, ProviderHeaders{}, ProviderRequestTransform{}, ProviderResponse{}, ProviderError{}, ProviderUsage{}, ProviderFinishReason{}, ProviderBalance{}, ProviderModels{}, s.errAt(lb, "expected '{' after provider name")
+				return ProviderRouting{}, ProviderHeaders{}, ProviderRequestTransform{}, ProviderResponse{}, ProviderError{}, ProviderUsage{}, ProviderFinishReason{}, ProviderBalance{}, ProviderModels{}, ProviderObservability{}, s.errAt(lb, "expected '{' after provider name")
 			}
-			r, h, rq, resp, e, u, fr, bq, mq, err := parseProviderBody(s)
+			r, h, rq, resp, e, u, fr, bq, mq, ob, err := parseProviderBody(s)
 			if err != nil {
-				return ProviderRouting{}, ProviderHeaders{}, ProviderRequestTransform{}, ProviderResponse{}, ProviderError{}, ProviderUsage{}, ProviderFinishReason{}, ProviderBalance{}, ProviderModels{}, err
+				return ProviderRouting{}, ProviderHeaders{}, ProviderRequestTransform{}, ProviderResponse{}, ProviderError{}, ProviderUsage{}, ProviderFinishReason{}, ProviderBalance{}, ProviderModels{}, ProviderObservability{}, err
 			}
 			routing = r
 			headers = h
@@ -46,13 +52,14 @@ func parseProviderConfig(path string, content string) (ProviderRouting, Provider
 			finish = fr
 			balance = bq
 			models = mq
+			observability = ob
 			continue
 		}
 	}
-	return routing, headers, req, response, perr, usage, finish, balance, models, nil
+	return routing, headers, req, response, perr, usage, finish, balance, models, observability, nil
 }
 
-func parseProviderBody(s *scanner) (ProviderRouting, ProviderHeaders, ProviderRequestTransform, ProviderResponse, ProviderError, ProviderUsage, ProviderFinishReason, ProviderBalance, ProviderModels, error) {
+func parseProviderBody(s *scanner) (ProviderRouting, ProviderHeaders, ProviderRequestTransform, ProviderResponse, ProviderError, ProviderUsage, ProviderFinishReason, ProviderBalance, ProviderModels, ProviderObservability, error) {
 	var routing ProviderRouting
 	var headers ProviderHeaders
 	var req ProviderRequestTransform
@@ -62,27 +69,34 @@ func parseProviderBody(s *scanner) (ProviderRouting, ProviderHeaders, ProviderRe
 	var finish ProviderFinishReason
 	var balance ProviderBalance
 	var models ProviderModels
+	var observability ProviderObservability
 	for {
 		tok := s.nextNonTrivia()
 		switch tok.kind {
 		case tokEOF:
-			return ProviderRouting{}, ProviderHeaders{}, ProviderRequestTransform{}, ProviderResponse{}, ProviderError{}, ProviderUsage{}, ProviderFinishReason{}, ProviderBalance{}, ProviderModels{}, s.errAt(tok, "unexpected EOF in provider block")
+			return ProviderRouting{}, ProviderHeaders{}, ProviderRequestTransform{}, ProviderResponse{}, ProviderError{}, ProviderUsage{}, ProviderFinishReason{}, ProviderBalance{}, ProviderModels{}, ProviderObservability{}, s.errAt(tok, "unexpected EOF in provider block")
 		case tokRBrace:
-			return routing, headers, req, response, perr, usage, finish, balance, models, nil
+			return routing, headers, req, response, perr, usage, finish, balance, models, observability, nil
 		case tokIdent:
 			switch tok.text {
 			case "metadata":
 				if err := skipStmtOrBlock(s); err != nil {
-					return ProviderRouting{}, ProviderHeaders{}, ProviderRequestTransform{}, ProviderResponse{}, ProviderError{}, ProviderUsage{}, ProviderFinishReason{}, ProviderBalance{}, ProviderModels{}, err
+					return ProviderRouting{}, ProviderHeaders{}, ProviderRequestTransform{}, ProviderResponse{}, ProviderError{}, ProviderUsage{}, ProviderFinishReason{}, ProviderBalance{}, ProviderModels{}, ProviderObservability{}, err
 				}
 			case "defaults":
 				if err := parseDefaultsBlock(s, &routing, &headers, &req, &response, &perr, &usage, &finish, &balance, &models); err != nil {
-					return ProviderRouting{}, ProviderHeaders{}, ProviderRequestTransform{}, ProviderResponse{}, ProviderError{}, ProviderUsage{}, ProviderFinishReason{}, ProviderBalance{}, ProviderModels{}, err
+					return ProviderRouting{}, ProviderHeaders{}, ProviderRequestTransform{}, ProviderResponse{}, ProviderError{}, ProviderUsage{}, ProviderFinishReason{}, ProviderBalance{}, ProviderModels{}, ProviderObservability{}, err
 				}
+			case "observability":
+				parsed, err := parseObservabilityBlock(s)
+				if err != nil {
+					return ProviderRouting{}, ProviderHeaders{}, ProviderRequestTransform{}, ProviderResponse{}, ProviderError{}, ProviderUsage{}, ProviderFinishReason{}, ProviderBalance{}, ProviderModels{}, ProviderObservability{}, err
+				}
+				observability = parsed
 			case "match":
 				m, mh, mreq, mr, me, mu, mfr, err := parseMatchBlock(s)
 				if err != nil {
-					return ProviderRouting{}, ProviderHeaders{}, ProviderRequestTransform{}, ProviderResponse{}, ProviderError{}, ProviderUsage{}, ProviderFinishReason{}, ProviderBalance{}, ProviderModels{}, err
+					return ProviderRouting{}, ProviderHeaders{}, ProviderRequestTransform{}, ProviderResponse{}, ProviderError{}, ProviderUsage{}, ProviderFinishReason{}, ProviderBalance{}, ProviderModels{}, ProviderObservability{}, err
 				}
 				routing.Matches = append(routing.Matches, m)
 				headers.Matches = append(headers.Matches, mh)
@@ -93,7 +107,7 @@ func parseProviderBody(s *scanner) (ProviderRouting, ProviderHeaders, ProviderRe
 				finish.Matches = append(finish.Matches, mfr)
 			default:
 				if err := skipStmtOrBlock(s); err != nil {
-					return ProviderRouting{}, ProviderHeaders{}, ProviderRequestTransform{}, ProviderResponse{}, ProviderError{}, ProviderUsage{}, ProviderFinishReason{}, ProviderBalance{}, ProviderModels{}, err
+					return ProviderRouting{}, ProviderHeaders{}, ProviderRequestTransform{}, ProviderResponse{}, ProviderError{}, ProviderUsage{}, ProviderFinishReason{}, ProviderBalance{}, ProviderModels{}, ProviderObservability{}, err
 				}
 			}
 		default:

--- a/onr-core/pkg/dslconfig/usage_modes.go
+++ b/onr-core/pkg/dslconfig/usage_modes.go
@@ -264,7 +264,7 @@ func validateAndBuildProviderFile(path string, content string, usageModes usageM
 			path, providerName, expected,
 		)
 	}
-	routing, headers, req, response, perr, usage, finish, balance, models, err := parseProviderConfig(path, content)
+	routing, headers, req, response, perr, usage, finish, balance, models, observability, err := parseProviderConfigWithObservability(path, content)
 	if err != nil {
 		return ProviderFile{}, false, err
 	}
@@ -308,19 +308,20 @@ func validateAndBuildProviderFile(path string, content string, usageModes usageM
 		return ProviderFile{}, false, err
 	}
 	return ProviderFile{
-		Name:     providerName,
-		Path:     path,
-		Content:  content,
-		Metadata: metadata,
-		Routing:  routing,
-		Headers:  headers,
-		Request:  resolvedReq,
-		Response: response,
-		Error:    perr,
-		Usage:    resolvedUsage,
-		Finish:   resolvedFinish,
-		Balance:  resolvedBalance,
-		Models:   resolvedModels,
+		Name:          providerName,
+		Path:          path,
+		Content:       content,
+		Metadata:      metadata,
+		Routing:       routing,
+		Headers:       headers,
+		Request:       resolvedReq,
+		Response:      response,
+		Error:         perr,
+		Usage:         resolvedUsage,
+		Finish:        resolvedFinish,
+		Balance:       resolvedBalance,
+		Models:        resolvedModels,
+		Observability: observability,
 	}, true, nil
 }
 

--- a/onr-core/pkg/dslspec/metadata.go
+++ b/onr-core/pkg/dslspec/metadata.go
@@ -41,6 +41,8 @@ var directiveMetadata = []DirectiveMetadata{
 	{Name: "defaults", Block: "provider", Hover: "`defaults { ... }`\n\nDefault phases shared by all `match` rules unless overridden.", IsBlock: true},
 	{Name: "match", Block: "provider", Hover: "`match api = \"...\" [stream = true|false] { ... }`\n\nRoute rule. First match wins.", IsBlock: true, BlockHeader: true},
 	{Name: "metadata", Block: "provider", Hover: "`metadata { provider_family <family>; signal_profile <profile>; }`\n\nDeclares provider identity and capacity signal profile metadata.", IsBlock: true},
+	{Name: "observability", Block: "provider", Hover: "`observability { upstream_request_id \"x-request-id\"; }`\n\nProvider-scoped upstream response observation rules.", IsBlock: true},
+	{Name: "upstream_request_id", Block: "observability", Hover: "`upstream_request_id \"Header-A\" \"Header-B\";`\n\nChecks configured upstream response headers in order and records the first non-empty value as upstream_request_id. Missing values do not affect forwarding and are not automatically passed downstream."},
 
 	{Name: "provider_family", Block: "metadata", Hover: "`provider_family <family>;`\n\nProvider family used for operations, debug output, and later capacity-signal grouping."},
 	{Name: "signal_profile", Block: "metadata", Hover: "`signal_profile <profile>;`\n\nSignal profile used by later provider capacity signal adaptors."},

--- a/onr-core/pkg/dslspec/metadata_test.go
+++ b/onr-core/pkg/dslspec/metadata_test.go
@@ -232,7 +232,7 @@ func TestBlockDirectiveNamesAndIsBlockDirective(t *testing.T) {
 	if IsBlockDirective("req_map") != false {
 		t.Fatalf("req_map should not be a block directive")
 	}
-	for _, must := range []string{"provider", "defaults", "match", "request", "after_req_map", "response", "usage_mode", "finish_reason_mode", "models_mode", "balance_mode"} {
+	for _, must := range []string{"provider", "defaults", "match", "observability", "request", "after_req_map", "response", "usage_mode", "finish_reason_mode", "models_mode", "balance_mode"} {
 		found := false
 		for _, b := range blocks {
 			if b == must {


### PR DESCRIPTION
## Description

Add provider-level observability configuration for extracting upstream request IDs from response headers.

This change introduces:

```conf
provider "openai" {
    observability {
        upstream_request_id "x-request-id" "openai-request-id";
    }
}
```

The configuration supports:

- Multiple response Header names in priority order;
- First configured non-empty Header value selection;
- HTTP Header name case-insensitive duplicate validation;
- Invalid Header name validation;
- Empty explicit rules;
- Provider-level scope shared by all `match` blocks.

The new configuration is parsed into:

```go
ProviderFile.Observability
```

and is supported by both merged-file loading and provider-directory validation/loading paths.

The change also updates DSL specification metadata so the new block and directive are visible to DSL tooling and parser metadata synchronization tests.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Manual test
- [x] Unit test
- [x] Integration test

Executed:

```bash
cd onr-core
go test ./...
```

The full ONR core test suite passed, including:

- DSL parser tests;
- Provider file validation tests;
- Provider directory loading tests;
- Observability rule validation tests;
- DSL specification metadata synchronization tests.

Added coverage includes:

- Parsing multiple `upstream_request_id` Header names;
- Preserving configured Header priority;
- Allowing an explicitly empty rule;
- Rejecting missing semicolon;
- Rejecting invalid Header names;
- Rejecting case-insensitive duplicate Header names;
- Keeping the rule unset when the block/directive is absent.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules