### PR TITLE
chore(ci): bump Go to 1.25.13 to clear stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/r9s-ai/open-next-router
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.4

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.25.12
+go 1.25.13
 
-toolchain go1.25.12
+toolchain go1.25.13
 
 use (
 	.

--- a/onr-core/go.mod
+++ b/onr-core/go.mod
@@ -1,6 +1,6 @@
 module github.com/r9s-ai/open-next-router/onr-core
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.4


### PR DESCRIPTION
## Description

`Security scans` 的两个 job（`Go vulnerabilities (onr)` / `Go vulnerabilities (onr-core)`）在 **main 上已经红了几天**（[run 31786746659](https://github.com/r9s-ai/open-next-router/actions/runs/31786746659)，8/14）。govulncheck 报的 4 个漏洞全部来自 **go1.25.12 标准库**，与任何业务改动无关：

| 漏洞 | 模块 | 调用点 |
|---|---|---|
| GO-2026-5972 | `encoding/asn1` | `pkg/oauthclient/client.go` 解析 RSA 私钥 |
| GO-2026-5026 | `net/http`（idna） | `pkg/pricing/catalog.go` 拉价格目录 |
| 其余 2 个 | `crypto/tls` | 同上 + `pkg/dslconfig/sse_response_ops.go` |

四个都在 **go1.25.13** 修复。CI 的 Go 版本经 `go-version-file` 取自 `go.mod` / `go.work`，所以只改这三处：

- `go.work`（`go` 与 `toolchain` 两行）
- `go.mod`
- `onr-core/go.mod`

`onr-lsp` 是独立子模块（现为 1.25.10），不在本次范围内。

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual test
- [x] Unit test

```
GOTOOLCHAIN=go1.25.13 govulncheck ./...   # onr-core: 4 个漏洞 -> 0
go build ./...                            # onr-core 与根模块均通过
go test ./...                             # 全绿
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

---

合并后 #87 上那两个红灯会一并转绿（[相关说明](https://github.com/r9s-ai/open-next-router/pull/87#issuecomment-5310868869)）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
