### PR TITLE
Feat/observability upstream request

### DIFF
--- a/DSL_SYNTAX.md
+++ b/DSL_SYNTAX.md
@@ -109,6 +109,26 @@ but it is recommended to keep it.
 provider "<name>" { ... }
 ```
 
+### 3.3 observability
+
+`observability` is provider-scoped and is shared by every `match` in that provider:
+
+```conf
+provider "openai" {
+  observability {
+    upstream_request_id "x-request-id" "openai-request-id";
+  }
+}
+```
+
+- `upstream_request_id` requires at least one quoted HTTP response-header name and must end with `;`.
+- Header names are checked in declaration order; the first non-empty, whitespace-trimmed value wins.
+- Header lookup is case-insensitive according to HTTP semantics. Only explicitly declared headers are examined.
+- The rule runs when upstream response headers arrive, before the response body is consumed, for both streaming and non-streaming responses.
+- The value is recorded as the `upstream_request_id` access-log field. It does not replace the client `request_id`.
+- Missing or empty headers do not fail or change forwarding. The value is not copied to the downstream response; use an explicit response header directive if forwarding is required.
+- Values are trimmed and limited to 256 bytes for logging.
+
 ## 4. match rules (selection)
 
 Supported forms:

--- a/DSL_SYNTAX_CN.md
+++ b/DSL_SYNTAX_CN.md
@@ -111,6 +111,26 @@ provider "openai" {
 provider "<name>" { ... }
 ```
 
+### 3.3 observability
+
+`observability` 位于 provider 块内，对该 provider 的所有 `match` 生效：
+
+```conf
+provider "openai" {
+  observability {
+    upstream_request_id "x-request-id" "openai-request-id";
+  }
+}
+```
+
+- `upstream_request_id` 至少需要一个带引号的 HTTP 响应头名称，并且语句必须以 `;` 结束。
+- 按声明顺序检查 Header，使用第一个去除首尾空白后仍非空的值。
+- Header 名称遵循 HTTP 语义大小写不敏感；只检查 DSL 明确声明的 Header，不做隐式猜测。
+- 收到上游响应头后、读取响应体之前执行；流式和非流式响应行为一致。
+- 结果写入观测/访问日志字段 `upstream_request_id`，不会覆盖客户端 `request_id`。
+- Header 缺失或为空不会导致请求失败，也不会改变转发；默认不会复制到下游响应，需要透传时必须使用显式响应 Header 指令。
+- 记录值会裁剪首尾空白，并限制为 256 字节。
+
 ## 4. match 规则（选择逻辑）
 
 语法（支持的条件）：

--- a/onr-core/pkg/dslconfig/observability_test.go
+++ b/onr-core/pkg/dslconfig/observability_test.go
@@ -59,20 +59,14 @@ func TestValidateProviderFile_ObservabilityRejectsInvalidRules(t *testing.T) {
 	}
 }
 
-func TestValidateProviderFile_ObservabilityAllowsEmptyRule(t *testing.T) {
-	pf, err := ValidateProviderFile(writeObservabilityProvider(t, `
+func TestValidateProviderFile_ObservabilityRejectsEmptyRule(t *testing.T) {
+	_, err := ValidateProviderFile(writeObservabilityProvider(t, `
 	observability {
 		upstream_request_id;
 	}
 `))
-	if err != nil {
-		t.Fatalf("ValidateProviderFile: %v", err)
-	}
-	if pf.Observability.UpstreamRequestID == nil {
-		t.Fatal("expected explicitly configured empty rule")
-	}
-	if len(pf.Observability.UpstreamRequestID.Headers) != 0 {
-		t.Fatalf("headers=%v want empty", pf.Observability.UpstreamRequestID.Headers)
+	if err == nil || !strings.Contains(err.Error(), "requires at least one header name") {
+		t.Fatalf("error=%v want missing-header validation error", err)
 	}
 }
 

--- a/onr-core/pkg/dslconfig/parse_observability.go
+++ b/onr-core/pkg/dslconfig/parse_observability.go
@@ -35,7 +35,6 @@ func parseObservabilityBlock(s *scanner) (ProviderObservability, error) {
 }
 
 func parseUpstreamRequestIDHeaders(s *scanner) ([]string, error) {
-	const maxHeaders = 16
 	headers := make([]string, 0, 2)
 	seen := map[string]struct{}{}
 	for {
@@ -52,10 +51,10 @@ func parseUpstreamRequestIDHeaders(s *scanner) ([]string, error) {
 			}
 			seen[key] = struct{}{}
 			headers = append(headers, name)
-			if len(headers) > maxHeaders {
-				return nil, s.errAt(tok, fmt.Sprintf("too many upstream request ID headers (maximum %d)", maxHeaders))
-			}
 		case tokSemicolon:
+			if len(headers) == 0 {
+				return nil, s.errAt(tok, "upstream_request_id requires at least one header name")
+			}
 			return headers, nil
 		case tokEOF:
 			return nil, s.errAt(tok, "expected ';' after upstream_request_id")

--- a/onr/internal/logx/access_fields.go
+++ b/onr/internal/logx/access_fields.go
@@ -72,6 +72,7 @@ var baseAccessLogContextFieldSpecs = []AccessLogContextFieldSpec{
 	{CtxKey: "onr.model", LogKey: "model"},
 	{CtxKey: "onr.usage_stage", LogKey: "usage_stage"},
 	{CtxKey: "onr.upstream_status", LogKey: "upstream_status"},
+	{CtxKey: "onr.upstream_request_id", LogKey: "upstream_request_id"},
 	{CtxKey: "onr.finish_reason", LogKey: "finish_reason"},
 	{CtxKey: "onr.ttft_ms", LogKey: "ttft_ms"},
 	{CtxKey: "onr.tps", LogKey: "tps"},

--- a/onr/internal/onrserver/accesslog/collector_test.go
+++ b/onr/internal/onrserver/accesslog/collector_test.go
@@ -20,6 +20,7 @@ func TestCollector_CollectMapsContextFields(t *testing.T) {
 	ctx.Set("X-Onr-Request-Id", "rid-1")
 	ctx.Set("onr.provider", "openai")
 	ctx.Set("onr.model", "gpt-4o-mini")
+	ctx.Set("onr.upstream_request_id", "upstream-req-1")
 	ctx.Set("onr.ttft_ms", int64(123))
 	ctx.Set("onr.tps", 45.6)
 
@@ -36,6 +37,9 @@ func TestCollector_CollectMapsContextFields(t *testing.T) {
 	if got["model"] != "gpt-4o-mini" {
 		t.Fatalf("unexpected model: %#v", got["model"])
 	}
+	if got["upstream_request_id"] != "upstream-req-1" {
+		t.Fatalf("unexpected upstream_request_id: %#v", got["upstream_request_id"])
+	}
 	if got["ttft_ms"] != int64(123) {
 		t.Fatalf("unexpected ttft_ms: %#v", got["ttft_ms"])
 	}
@@ -44,6 +48,23 @@ func TestCollector_CollectMapsContextFields(t *testing.T) {
 	}
 	if got["latency_ms"] != int64(2000) {
 		t.Fatalf("unexpected latency_ms: %#v", got["latency_ms"])
+	}
+}
+
+func TestCollector_CollectKeepsClientAndUpstreamRequestIDsSeparate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = httptest.NewRequest("GET", "/v1/models", nil)
+	ctx.Set("X-Onr-Request-Id", "client-request-1")
+	ctx.Set("onr.upstream_request_id", "upstream-request-1")
+
+	got := NewCollector("X-Onr-Request-Id", false, "").Collect(ctx, time.Second)
+	if got["request_id"] != "client-request-1" {
+		t.Fatalf("unexpected request_id: %#v", got["request_id"])
+	}
+	if got["upstream_request_id"] != "upstream-request-1" {
+		t.Fatalf("unexpected upstream_request_id: %#v", got["upstream_request_id"])
 	}
 }
 

--- a/onr/internal/proxy/observability_test.go
+++ b/onr/internal/proxy/observability_test.go
@@ -70,6 +70,27 @@ func TestRecordUpstreamRequestIDMissingDoesNotSetOrForward(t *testing.T) {
 	}
 }
 
+func TestUpstreamRequestIDIsStillPassedThroughToDownstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	header := http.Header{}
+	header.Set("X-Request-ID", "upstream-123")
+
+	// Extraction records the value but does not mutate the upstream response headers.
+	recordUpstreamRequestID(c, dslconfig.ProviderFile{Observability: dslconfig.ProviderObservability{
+		UpstreamRequestID: &dslconfig.UpstreamRequestIDRule{Headers: []string{"x-request-id"}},
+	}}, &http.Response{Header: header})
+	copyHeadersToClient(c, header, false)
+
+	if got := c.GetString("onr.upstream_request_id"); got != "upstream-123" {
+		t.Fatalf("upstream_request_id=%q want upstream-123", got)
+	}
+	if got := w.Header().Get("X-Request-ID"); got != "upstream-123" {
+		t.Fatalf("downstream X-Request-ID=%q want upstream-123", got)
+	}
+}
+
 func TestRecordUpstreamRequestIDTruncatesAt256Bytes(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())

--- a/onr/internal/proxy/observability_test.go
+++ b/onr/internal/proxy/observability_test.go
@@ -1,0 +1,84 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/r9s-ai/open-next-router/onr-core/pkg/dslconfig"
+	"github.com/r9s-ai/open-next-router/onr-core/pkg/dslmeta"
+)
+
+func TestRecordUpstreamRequestIDUsesConfiguredOrderAndTrims(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	header := http.Header{}
+	header.Set("X-Request-ID", "  ")
+	header.Set("OpenAI-Request-ID", "  configured-id  ")
+	header.Set("X-Implicit-ID", "must-not-be-used")
+	resp := &http.Response{Header: header}
+	recordUpstreamRequestID(c, dslconfig.ProviderFile{Observability: dslconfig.ProviderObservability{
+		UpstreamRequestID: &dslconfig.UpstreamRequestIDRule{Headers: []string{"x-request-id", "openai-request-id"}},
+	}}, resp)
+	if got := c.GetString("onr.upstream_request_id"); got != "configured-id" {
+		t.Fatalf("upstream_request_id=%q want configured-id", got)
+	}
+}
+
+func TestDoUpstreamRequestRecordsProviderRequestID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Request-ID", "  ")
+		w.Header().Set("OpenAI-Request-ID", "upstream-123")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	gc, _ := gin.CreateTestContext(httptest.NewRecorder())
+	gc.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{}`))
+	c := &Client{HTTP: &http.Client{Timeout: 3 * time.Second}, WriteTimeout: 3 * time.Second}
+	pf := dslconfig.ProviderFile{Observability: dslconfig.ProviderObservability{
+		UpstreamRequestID: &dslconfig.UpstreamRequestIDRule{Headers: []string{"x-request-id", "openai-request-id"}},
+	}}
+	resp, cancel, err := c.doUpstreamRequest(gc, "openai", &pf, &dslmeta.Meta{
+		API: "chat.completions", BaseURL: srv.URL, RequestURLPath: "/",
+	}, []byte(`{}`))
+	if err != nil {
+		t.Fatalf("doUpstreamRequest error: %v", err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close(); cancel() })
+	if got := gc.GetString("onr.upstream_request_id"); got != "upstream-123" {
+		t.Fatalf("upstream_request_id=%q want upstream-123", got)
+	}
+}
+
+func TestRecordUpstreamRequestIDMissingDoesNotSetOrForward(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	recordUpstreamRequestID(c, dslconfig.ProviderFile{Observability: dslconfig.ProviderObservability{
+		UpstreamRequestID: &dslconfig.UpstreamRequestIDRule{Headers: []string{"x-request-id"}},
+	}}, &http.Response{Header: http.Header{"X-Other-Id": []string{"implicit-id"}}})
+	if _, ok := c.Get("onr.upstream_request_id"); ok {
+		t.Fatal("upstream_request_id should be absent when configured headers are missing")
+	}
+	if got := w.Header().Get("x-request-id"); got != "" {
+		t.Fatalf("response unexpectedly forwarded upstream request ID: %q", got)
+	}
+}
+
+func TestRecordUpstreamRequestIDTruncatesAt256Bytes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	header := http.Header{}
+	header.Set("X-Request-ID", strings.Repeat("x", 300))
+	recordUpstreamRequestID(c, dslconfig.ProviderFile{Observability: dslconfig.ProviderObservability{
+		UpstreamRequestID: &dslconfig.UpstreamRequestIDRule{Headers: []string{"x-request-id"}},
+	}}, &http.Response{Header: header})
+	if got := c.GetString("onr.upstream_request_id"); len(got) != 256 {
+		t.Fatalf("upstream_request_id length=%d want 256", len(got))
+	}
+}

--- a/onr/internal/proxy/upstream.go
+++ b/onr/internal/proxy/upstream.go
@@ -21,7 +21,11 @@ import (
 // doUpstreamRequest requires a non-nil provider file and request meta from buildProxyCtx.
 func (c *Client) doUpstreamRequest(gc *gin.Context, provider string, pf *dslconfig.ProviderFile, m *dslmeta.Meta, reqBody []byte) (*http.Response, context.CancelFunc, error) {
 	if strings.EqualFold(strings.TrimSpace(m.UpstreamTransport), "aws_sdk") {
-		return c.doBedrockRuntimeRequest(gc, provider, pf, m, reqBody)
+		resp, cancel, err := c.doBedrockRuntimeRequest(gc, provider, pf, m, reqBody)
+		if err == nil {
+			recordUpstreamRequestID(gc, *pf, resp)
+		}
+		return resp, cancel, err
 	}
 	baseURL := m.BaseURL
 	if baseURL == "" {
@@ -72,9 +76,28 @@ func (c *Client) doUpstreamRequest(gc *gin.Context, provider string, pf *dslconf
 			m.OAuthAccessToken = ""
 			continue
 		}
+		recordUpstreamRequestID(gc, *pf, resp)
 		return resp, cancel, nil
 	}
 	return lastResp, cancel, nil
+}
+
+// recordUpstreamRequestID extracts only explicitly configured response headers.
+// It runs after response headers arrive and before either response path consumes the body.
+func recordUpstreamRequestID(gc *gin.Context, pf dslconfig.ProviderFile, resp *http.Response) {
+	rule := pf.Observability.UpstreamRequestID
+	if rule == nil {
+		return
+	}
+	for _, name := range rule.Headers {
+		if value := strings.TrimSpace(resp.Header.Get(name)); value != "" {
+			if len(value) > 256 {
+				value = value[:256]
+			}
+			gc.Set("onr.upstream_request_id", value)
+			return
+		}
+	}
 }
 
 func isEffectiveStream(clientStream bool, resp *http.Response, respDir *dslconfig.ResponseDirective) bool {


### PR DESCRIPTION

## Description

Add provider-scoped upstream request ID observability for the ONR DSL and runtime.

This change allows a provider to explicitly declare an ordered list of upstream response headers:

```conf
provider "openai" {
  observability {
    upstream_request_id "x-request-id" "openai-request-id";
  }
}
```

The runtime checks the configured headers in order, uses the first non-empty value, trims surrounding whitespace, limits the recorded value to 256 bytes, and writes it to the `upstream_request_id` access-log field.

The extraction runs in the common upstream response path before response body processing, so streaming and non-streaming responses use the same behavior. The client `request_id` is kept separate and is not overwritten.

Missing or empty headers do not affect request forwarding. The original upstream response headers are preserved and continue to be passed through unchanged.

The DSL parser now:

- Requires at least one header name;
- Validates HTTP header names;
- Rejects duplicate header names case-insensitively;
- Does not impose an artificial maximum number of configured headers.

The English and Chinese DSL syntax documentation has also been updated.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

The following tests were run:

```bash
go test ./onr/internal/proxy -count=1 -v
go test ./onr-core/pkg/dslconfig ./onr/internal/onrserver/accesslog ./onr/internal/logx -count=1
```

The tests cover:

- Provider-level DSL parsing and validation;
- Rejection of an empty `upstream_request_id` rule;
- Ordered Header fallback;
- Case-insensitive Header lookup;
- Whitespace trimming;
- 256-byte truncation;
- Runtime extraction from the common `doUpstreamRequest` path;
- Missing Header behavior;
- Client `request_id` and upstream `upstream_request_id` remaining separate;
- Access-log collection;
- Upstream request ID remaining available for downstream response passthrough.

- [ ] Manual test
- [x] Unit test
- [x] Integration test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
