### PR TITLE
Revert "chore(ci): bump Go to 1.25.13 to clear stdlib vulnerabilities"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/r9s-ai/open-next-router
 
-go 1.25.13
+go 1.25.12
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.4

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.25.13
+go 1.25.12
 
-toolchain go1.25.13
+toolchain go1.25.12
 
 use (
 	.

--- a/onr-core/go.mod
+++ b/onr-core/go.mod
@@ -1,6 +1,6 @@
 module github.com/r9s-ai/open-next-router/onr-core
 
-go 1.25.13
+go 1.25.12
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.4


### PR DESCRIPTION
Reverts r9s-ai/open-next-router#89