### PR TITLE
fix(observability): update upstream request ID test call

### DIFF
--- a/onr/internal/proxy/observability_test.go
+++ b/onr/internal/proxy/observability_test.go
@@ -45,7 +45,7 @@ func TestDoUpstreamRequestRecordsProviderRequestID(t *testing.T) {
 	}}
 	resp, cancel, err := c.doUpstreamRequest(gc, "openai", &pf, &dslmeta.Meta{
 		API: "chat.completions", BaseURL: srv.URL, RequestURLPath: "/",
-	}, []byte(`{}`))
+	}, []byte(`{}`), "")
 	if err != nil {
 		t.Fatalf("doUpstreamRequest error: %v", err)
 	}


### PR DESCRIPTION

## Description

Add provider-scoped upstream request ID observability to the ONR DSL and runtime.

Providers can explicitly declare an ordered list of upstream response headers:

```conf
provider "openai" {
  observability {
    upstream_request_id "x-request-id" "openai-request-id";
  }
}
```

The runtime checks these headers in declaration order, records the first non-empty value as `upstream_request_id`, trims surrounding whitespace, and limits the recorded value to 256 bytes.

The extraction runs in the common upstream response path before response body processing, so streaming and non-streaming responses share the same behavior. The client `request_id` remains separate and is not overwritten.

Missing or empty headers do not affect request forwarding. The original upstream response headers remain unchanged and continue to be passed through.

The DSL parser and documentation were updated to:

- Require at least one header name;
- Validate HTTP header names;
- Reject duplicate names case-insensitively;
- Allow an arbitrary number of configured headers;
- Document provider scope, ordering, missing-header behavior, logging, and passthrough semantics.

The runtime test was also updated for the current `doUpstreamRequest` signature after rebasing onto the latest `main`.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

The following tests were run:

```bash
go test ./onr/internal/proxy -count=1 -v

go test ./onr-core/pkg/dslconfig \
         ./onr/internal/onrserver/accesslog \
         ./onr/internal/logx \
         -count=1
```

The tests cover:

- Provider-level DSL parsing and validation;
- Empty `upstream_request_id` rule rejection;
- Ordered Header fallback;
- Case-insensitive Header lookup;
- Whitespace trimming;
- 256-byte truncation;
- Runtime extraction from `doUpstreamRequest`;
- Missing Header behavior;
- Client `request_id` and upstream `upstream_request_id` remaining separate;
- Access-log collection;
- Upstream request ID remaining available for downstream passthrough;
- Compatibility with the current `doUpstreamRequest` signature.

- [ ] Manual test
- [x] Unit test
- [x] Integration test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
```