### PR TITLE
Feat/dslconfig model channel max price

### DIFF
--- a/DSL_SYNTAX.md
+++ b/DSL_SYNTAX.md
@@ -410,7 +410,8 @@ request {
 
 - Applies lightweight transforms to the upstream request JSON.
 - JSONPath (v0.1) supports an object-path subset: `$.a.b.c` (no array indices for these request ops).
-- `json_set` value expressions support: `true/false/null`, integer, string literal, variable, `concat(...)`, and `template(...)`.
+- `json_set` value expressions support: `true/false/null`, integer, decimal, string literal, variable, `concat(...)`, and `template(...)`.
+- `$model_channel.max_price.*` variables are JSON numbers and are only valid as unquoted JSON value expressions. Request transformation fails when the corresponding price is not configured.
 - `json_set` sets a field and creates missing object-path parents.
 - `json_replace` only replaces an existing target path; missing paths are no-op and no parent object or leaf field is created.
 - `json_set_if_absent` only sets when the path does not exist; existing values are preserved.
@@ -1441,6 +1442,14 @@ The original request model (string).
 
 `$request.model_mapped`  
 The mapped model (string). Defaults to `$request.model` unless modified via `model_map` / `model_map_default`.
+
+`$model_channel.max_price.prompt`, `$model_channel.max_price.completion`,
+`$model_channel.max_price.request`, `$model_channel.max_price.image`
+
+OpenRouter `max_price` values for the selected model-channel (JSON numbers). These variables are supported only as
+bare JSON value expressions for `json_set`, `json_replace`, `json_set_if_absent`, and `json_map_value`. They are not
+string variables and cannot be used in `concat(...)`, `template(...)`, headers, or paths. Do not quote them. Request
+transformation fails if the corresponding price field is not configured.
 
 Expression forms (v0.1):
 
@@ -2547,9 +2556,10 @@ Multiple: yes
 
 ## 8. Built-in variables (reference)
 
-This section lists the built-in variables available in v0.1 `<expr>` positions (all are strings).
+This section lists the v0.1 built-in variables. All variables are strings unless explicitly documented as JSON numbers.
 
-> Variables are evaluated at runtime; if a variable is empty in the current request context, it expands to an empty string.
+> Variables are evaluated at runtime. Empty string variables expand to an empty string; an unconfigured JSON number
+> variable returns a request transformation error.
 
 ### 8.1 `$channel.*`
 
@@ -2588,7 +2598,30 @@ Mapped model name. Defaults to `$request.model`; can be modified by `model_map` 
 Upstream task/operation id for long-running operation routes. For Gemini Veo this is the operation
 name returned by `predictLongRunning`, for example `models/veo-3.1-generate-preview/operations/abc`.
 
-### 8.5 Examples
+### 8.5 `$model_channel.max_price.*`
+
+The following variables are JSON numbers:
+
+- `$model_channel.max_price.prompt`
+- `$model_channel.max_price.completion`
+- `$model_channel.max_price.request`
+- `$model_channel.max_price.image`
+
+Values come from `PricingConfig.max_price` for the selected model-channel. They are valid only as bare JSON operation
+value expressions, not in `concat(...)`, `template(...)`, headers, or paths. Quoting a variable makes it a literal
+string.
+
+```conf
+request {
+  json_set "$.provider.max_price.prompt" $model_channel.max_price.prompt;
+  json_set "$.provider.max_price.completion" $model_channel.max_price.completion;
+}
+```
+
+If the DSL references a variable whose corresponding model-channel price is not configured, request transformation
+returns an error.
+
+### 8.6 Examples
 
 ```conf
 request {

--- a/DSL_SYNTAX_CN.md
+++ b/DSL_SYNTAX_CN.md
@@ -427,7 +427,8 @@ request {
 
 - 用途：对”已生成的上游请求 JSON”做轻量变换（在旧 adaptor 的 `ConvertRequest` 之后执行）
 - JSONPath（v0.1）仅支持对象路径：`$.a.b.c`（不支持数组下标 `[]`）
-- `json_set` 的值表达式支持：`true/false/null`、整数、字符串字面量、变量、`concat(...)`、`template(...)`
+- `json_set` 的值表达式支持：`true/false/null`、整数、小数、字符串字面量、变量、`concat(...)`、`template(...)`
+- `$model_channel.max_price.*` 是 JSON number 变量，只能作为不带引号的 JSON 值表达式使用；对应价格未配置时，请求转换会报错
 - `json_set`：设置字段；不存在的对象路径会自动创建
 - `json_replace`：仅当目标路径已存在时替换字段；路径不存在时为 no-op，不会创建缺失对象或字段
 - `json_set_if_absent`：仅当路径不存在时写入；已存在值会保留
@@ -1467,6 +1468,14 @@ metrics {
 
 `$request.model_mapped`  
 映射后的模型名（字符串）。默认等于 `$request.model`，可通过 `request { model_map ...; model_map_default ...; }` 修改。
+
+`$model_channel.max_price.prompt`、`$model_channel.max_price.completion`、
+`$model_channel.max_price.request`、`$model_channel.max_price.image`
+
+当前选中 model-channel 的 OpenRouter `max_price`（JSON number）。这些变量仅支持作为
+`json_set`、`json_replace`、`json_set_if_absent`、`json_map_value` 的裸 JSON 值表达式，
+不支持字符串、`concat(...)`、`template(...)`、header 或 path 表达式。变量不能加引号；
+如果对应价格字段未配置，请求转换会报错。
 
 表达式形态（v0.1）：
 
@@ -2560,9 +2569,9 @@ Multiple: yes
 
 ## 8. 内置变量参考
 
-本节列出 v0.1 可在 `<expr>` 中使用的内置变量（均为字符串）。
+本节列出 v0.1 内置变量。除单独标明的 JSON number 变量外，其余变量均为字符串。
 
-> 说明：变量在运行期求值；当某变量在当前请求上下文中为空时，会展开为空字符串。
+> 说明：变量在运行期求值；字符串变量为空时会展开为空字符串。JSON number 变量未配置时会返回请求转换错误。
 
 ### 8.1 `$channel.*`
 
@@ -2601,7 +2610,28 @@ Provider location。对 Vertex AI 通常是 `global` 或 `us-central1` 这类区
 长任务查询路由中的上游任务/operation id。对 Gemini Veo 来说，它是 `predictLongRunning`
 返回的 operation name，例如 `models/veo-3.1-generate-preview/operations/abc`。
 
-### 8.5 使用示例
+### 8.5 `$model_channel.max_price.*`
+
+以下变量是 JSON number 变量：
+
+- `$model_channel.max_price.prompt`
+- `$model_channel.max_price.completion`
+- `$model_channel.max_price.request`
+- `$model_channel.max_price.image`
+
+值来自当前选中 model-channel 的 `PricingConfig.max_price`。它们只能作为 JSON 操作的裸值表达式使用，
+不能用于 `concat(...)`、`template(...)`、header 或 path。不要给变量加引号，否则会成为普通字符串。
+
+```conf
+request {
+  json_set "$.provider.max_price.prompt" $model_channel.max_price.prompt;
+  json_set "$.provider.max_price.completion" $model_channel.max_price.completion;
+}
+```
+
+如果 DSL 引用了某个变量，但当前 model-channel 没有配置对应价格字段，请求转换会返回错误。
+
+### 8.6 使用示例
 
 ```conf
 request {

--- a/onr-core/pkg/dslconfig/core_constants.go
+++ b/onr-core/pkg/dslconfig/core_constants.go
@@ -1,15 +1,19 @@
 package dslconfig
 
 const (
-	exprChannelBaseURL   = "$channel.base_url"
-	exprChannelKey       = "$channel.key"
-	exprChannelLocation  = "$channel.location"
-	exprCredentialProjID = "$credential.project_id"
-	exprOAuthAccessToken = "$oauth.access_token"
-	exprRequestModel     = "$request.model"
-	exprRequestMapped    = "$request.model_mapped"
-	exprTaskID           = "$task.id"
-	exprTaskUpstreamID   = "$task.upstream_id"
+	exprChannelBaseURL                 = "$channel.base_url"
+	exprChannelKey                     = "$channel.key"
+	exprChannelLocation                = "$channel.location"
+	exprCredentialProjID               = "$credential.project_id"
+	exprOAuthAccessToken               = "$oauth.access_token"
+	exprRequestModel                   = "$request.model"
+	exprRequestMapped                  = "$request.model_mapped"
+	exprTaskID                         = "$task.id"
+	exprTaskUpstreamID                 = "$task.upstream_id"
+	exprModelChannelMaxPricePrompt     = "$model_channel.max_price.prompt"
+	exprModelChannelMaxPriceCompletion = "$model_channel.max_price.completion"
+	exprModelChannelMaxPriceRequest    = "$model_channel.max_price.request"
+	exprModelChannelMaxPriceImage      = "$model_channel.max_price.image"
 
 	jsonOpSet           = "json_set"
 	jsonOpReplace       = "json_replace"

--- a/onr-core/pkg/dslconfig/json_map_clamp_test.go
+++ b/onr-core/pkg/dslconfig/json_map_clamp_test.go
@@ -218,18 +218,18 @@ func TestApplyJSONOps_MapValueAndClamp(t *testing.T) {
 func TestEvalJSONValueExprFloatLiteral(t *testing.T) {
 	t.Parallel()
 	m := &dslmeta.Meta{}
-	if got := evalJSONValueExpr(m, "1.0"); got != 1.0 {
+	if got, err := evalJSONValueExpr(m, "1.0"); err != nil || got != 1.0 {
 		t.Fatalf("expected float 1.0, got %#v", got)
 	}
-	if got := evalJSONValueExpr(m, "-0.5"); got != -0.5 {
+	if got, err := evalJSONValueExpr(m, "-0.5"); err != nil || got != -0.5 {
 		t.Fatalf("expected float -0.5, got %#v", got)
 	}
 	// ints stay ints
-	if got := evalJSONValueExpr(m, "32000"); got != 32000 {
+	if got, err := evalJSONValueExpr(m, "32000"); err != nil || got != 32000 {
 		t.Fatalf("expected int 32000, got %#v", got)
 	}
 	// words never become floats
-	if got := evalJSONValueExpr(m, "infe"); got == float64(0) {
+	if got, err := evalJSONValueExpr(m, "infe"); err != nil || got == float64(0) {
 		t.Fatalf("expected non-float for word, got %#v", got)
 	}
 }

--- a/onr-core/pkg/dslconfig/json_ops.go
+++ b/onr-core/pkg/dslconfig/json_ops.go
@@ -41,15 +41,27 @@ func ApplyJSONOps(meta *dslmeta.Meta, in map[string]any, ops []JSONOp) (map[stri
 func applyJSONOp(meta *dslmeta.Meta, obj map[string]any, op JSONOp) (bool, error) {
 	switch op.Op {
 	case jsonOpSet:
-		return jsonSet(obj, op.Path, evalJSONValueExpr(meta, op.ValueExpr))
+		value, err := evalJSONValueExpr(meta, op.ValueExpr)
+		if err != nil {
+			return false, err
+		}
+		return jsonSet(obj, op.Path, value)
 	case jsonOpReplace:
-		return jsonReplace(obj, op.Path, evalJSONValueExpr(meta, op.ValueExpr))
+		value, err := evalJSONValueExpr(meta, op.ValueExpr)
+		if err != nil {
+			return false, err
+		}
+		return jsonReplace(obj, op.Path, value)
 	case jsonOpSetIfAbsent:
 		exists, err := jsonPathExists(obj, op.Path)
 		if err != nil || exists {
 			return false, err
 		}
-		return jsonSet(obj, op.Path, evalJSONValueExpr(meta, op.ValueExpr))
+		value, err := evalJSONValueExpr(meta, op.ValueExpr)
+		if err != nil {
+			return false, err
+		}
+		return jsonSet(obj, op.Path, value)
 	case jsonOpDel:
 		return jsonDel(obj, op.Path)
 	case jsonOpDelIfMissing:
@@ -78,7 +90,11 @@ func applyJSONOp(meta *dslmeta.Meta, obj map[string]any, op JSONOp) (bool, error
 	case jsonOpDelWithCond:
 		return jsonDelWithCondition(obj, op.Path, op.FieldName, op.Patterns)
 	case jsonOpMapValue:
-		return jsonMapValue(obj, op.Path, op.MatchValue, evalJSONValueExpr(meta, op.ValueExpr))
+		value, err := evalJSONValueExpr(meta, op.ValueExpr)
+		if err != nil {
+			return false, err
+		}
+		return jsonMapValue(obj, op.Path, op.MatchValue, value)
 	case jsonOpClamp:
 		return jsonClamp(obj, op.Path, op.ClampRange)
 	default:
@@ -144,40 +160,44 @@ func jsonPathExists(root map[string]any, path string) (bool, error) {
 	return ok, nil
 }
 
-func evalJSONValueExpr(meta *dslmeta.Meta, expr string) any {
+func evalJSONValueExpr(meta *dslmeta.Meta, expr string) (any, error) {
 	raw := strings.TrimSpace(expr)
 	if raw == "" {
-		return ""
+		return "", nil
 	}
 	switch raw {
 	case "true":
-		return true
+		return true, nil
 	case "false":
-		return false
+		return false, nil
 	case "null":
-		return nil
+		return nil, nil
 	}
 	if strings.HasPrefix(raw, "\"") && strings.HasSuffix(raw, "\"") {
-		return unquoteString(raw)
+		return unquoteString(raw), nil
 	}
 	if i, err := strconv.Atoi(raw); err == nil {
-		return i
+		return i, nil
 	}
 	if f, ok := parseFloatLiteral(raw); ok {
-		return f
+		return f, nil
 	}
-	if value, ok := evalBuiltinJSONNumberVariable(meta, raw); ok {
-		return value
+	if isBuiltinJSONNumberVariable(raw) {
+		value, ok := evalBuiltinJSONNumberVariable(meta, raw)
+		if !ok {
+			return nil, fmt.Errorf("JSON number variable %q is unavailable; check the model channel max_price configuration", raw)
+		}
+		return value, nil
 	}
 	// fall back to string expression evaluation
-	return evalStringExpr(raw, meta)
+	return evalStringExpr(raw, meta), nil
 }
 
 func evalBuiltinJSONNumberVariable(meta *dslmeta.Meta, expr string) (float64, bool) {
 	if meta == nil || meta.ModelChannelMaxPrice == nil {
 		return 0, false
 	}
-	var value float64
+	var value *float64
 	switch strings.TrimSpace(expr) {
 	case exprModelChannelMaxPricePrompt:
 		value = meta.ModelChannelMaxPrice.Prompt
@@ -190,7 +210,10 @@ func evalBuiltinJSONNumberVariable(meta *dslmeta.Meta, expr string) (float64, bo
 	default:
 		return 0, false
 	}
-	return value, true
+	if value == nil {
+		return 0, false
+	}
+	return *value, true
 }
 
 // parseFloatLiteral parses a plain decimal float literal like "1.0" or "-0.5".

--- a/onr-core/pkg/dslconfig/json_ops.go
+++ b/onr-core/pkg/dslconfig/json_ops.go
@@ -166,8 +166,31 @@ func evalJSONValueExpr(meta *dslmeta.Meta, expr string) any {
 	if f, ok := parseFloatLiteral(raw); ok {
 		return f
 	}
+	if value, ok := evalBuiltinJSONNumberVariable(meta, raw); ok {
+		return value
+	}
 	// fall back to string expression evaluation
 	return evalStringExpr(raw, meta)
+}
+
+func evalBuiltinJSONNumberVariable(meta *dslmeta.Meta, expr string) (float64, bool) {
+	if meta == nil || meta.ModelChannelMaxPrice == nil {
+		return 0, false
+	}
+	var value float64
+	switch strings.TrimSpace(expr) {
+	case exprModelChannelMaxPricePrompt:
+		value = meta.ModelChannelMaxPrice.Prompt
+	case exprModelChannelMaxPriceCompletion:
+		value = meta.ModelChannelMaxPrice.Completion
+	case exprModelChannelMaxPriceRequest:
+		value = meta.ModelChannelMaxPrice.Request
+	case exprModelChannelMaxPriceImage:
+		value = meta.ModelChannelMaxPrice.Image
+	default:
+		return 0, false
+	}
+	return value, true
 }
 
 // parseFloatLiteral parses a plain decimal float literal like "1.0" or "-0.5".

--- a/onr-core/pkg/dslconfig/json_ops_test.go
+++ b/onr-core/pkg/dslconfig/json_ops_test.go
@@ -8,6 +8,35 @@ import (
 	"github.com/r9s-ai/open-next-router/onr-core/pkg/dslmeta"
 )
 
+func TestApplyJSONOps_ModelChannelMaxPriceIsJSONNumber(t *testing.T) {
+	price := 2.5
+	meta := &dslmeta.Meta{
+		ModelChannelMaxPrice: &dslmeta.ModelChannelMaxPrice{Prompt: price},
+	}
+	root, err := ApplyJSONOps(meta, map[string]any{}, []JSONOp{{
+		Op: "json_set", Path: "$.provider.max_price.prompt", ValueExpr: "$model_channel.max_price.prompt",
+	}})
+	if err != nil {
+		t.Fatalf("ApplyJSONOps: %v", err)
+	}
+	got := root["provider"].(map[string]any)["max_price"].(map[string]any)["prompt"]
+	if got != price {
+		t.Fatalf("prompt=%v (%T), want %v (float64)", got, got, price)
+	}
+}
+
+func TestApplyJSONOps_RequestModelNumericStringRemainsString(t *testing.T) {
+	root, err := ApplyJSONOps(&dslmeta.Meta{OriginModelName: "123"}, map[string]any{}, []JSONOp{{
+		Op: "json_set", Path: "$.model", ValueExpr: "$request.model",
+	}})
+	if err != nil {
+		t.Fatalf("ApplyJSONOps: %v", err)
+	}
+	if got, ok := root["model"].(string); !ok || got != "123" {
+		t.Fatalf("model=%v (%T), want string 123", root["model"], root["model"])
+	}
+}
+
 func TestApplyJSONOps_TableDriven(t *testing.T) {
 	t.Parallel()
 

--- a/onr-core/pkg/dslconfig/json_ops_test.go
+++ b/onr-core/pkg/dslconfig/json_ops_test.go
@@ -3,6 +3,7 @@ package dslconfig
 import (
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/r9s-ai/open-next-router/onr-core/pkg/dslmeta"
@@ -11,7 +12,7 @@ import (
 func TestApplyJSONOps_ModelChannelMaxPriceIsJSONNumber(t *testing.T) {
 	price := 2.5
 	meta := &dslmeta.Meta{
-		ModelChannelMaxPrice: &dslmeta.ModelChannelMaxPrice{Prompt: price},
+		ModelChannelMaxPrice: &dslmeta.ModelChannelMaxPrice{Prompt: &price},
 	}
 	root, err := ApplyJSONOps(meta, map[string]any{}, []JSONOp{{
 		Op: "json_set", Path: "$.provider.max_price.prompt", ValueExpr: "$model_channel.max_price.prompt",
@@ -22,6 +23,53 @@ func TestApplyJSONOps_ModelChannelMaxPriceIsJSONNumber(t *testing.T) {
 	got := root["provider"].(map[string]any)["max_price"].(map[string]any)["prompt"]
 	if got != price {
 		t.Fatalf("prompt=%v (%T), want %v (float64)", got, got, price)
+	}
+}
+
+func TestApplyJSONOps_ModelChannelMaxPriceExplicitZeroIsJSONNumber(t *testing.T) {
+	price := 0.0
+	meta := &dslmeta.Meta{
+		ModelChannelMaxPrice: &dslmeta.ModelChannelMaxPrice{Prompt: &price},
+	}
+	root, err := ApplyJSONOps(meta, map[string]any{}, []JSONOp{{
+		Op: "json_set", Path: "$.provider.max_price.prompt", ValueExpr: "$model_channel.max_price.prompt",
+	}})
+	if err != nil {
+		t.Fatalf("ApplyJSONOps: %v", err)
+	}
+	got := root["provider"].(map[string]any)["max_price"].(map[string]any)["prompt"]
+	if got != price {
+		t.Fatalf("prompt=%v (%T), want explicit zero float64", got, got)
+	}
+}
+
+func TestApplyJSONOps_ModelChannelMaxPriceMissingReturnsError(t *testing.T) {
+	_, err := ApplyJSONOps(&dslmeta.Meta{
+		ModelChannelMaxPrice: &dslmeta.ModelChannelMaxPrice{},
+	}, map[string]any{}, []JSONOp{{
+		Op: "json_set", Path: "$.provider.max_price.prompt", ValueExpr: "$model_channel.max_price.prompt",
+	}})
+	if err == nil {
+		t.Fatal("expected missing model channel max price error")
+	}
+	if !strings.Contains(err.Error(), "$model_channel.max_price.prompt") {
+		t.Fatalf("error=%q, want variable name", err)
+	}
+}
+
+func TestApplyJSONOps_ModelChannelMaxPricePartiallyConfiguredReturnsError(t *testing.T) {
+	prompt := 1.5
+	_, err := ApplyJSONOps(&dslmeta.Meta{
+		ModelChannelMaxPrice: &dslmeta.ModelChannelMaxPrice{Prompt: &prompt},
+	}, map[string]any{}, []JSONOp{
+		{Op: "json_set", Path: "$.provider.max_price.prompt", ValueExpr: "$model_channel.max_price.prompt"},
+		{Op: "json_set", Path: "$.provider.max_price.completion", ValueExpr: "$model_channel.max_price.completion"},
+	})
+	if err == nil {
+		t.Fatal("expected missing completion max price error")
+	}
+	if !strings.Contains(err.Error(), "$model_channel.max_price.completion") {
+		t.Fatalf("error=%q, want missing completion variable", err)
 	}
 }
 

--- a/onr-core/pkg/dslconfig/request_validation_test.go
+++ b/onr-core/pkg/dslconfig/request_validation_test.go
@@ -33,6 +33,21 @@ func validateValidationConf(t *testing.T, requestBody string) (ProviderRequestTr
 	return validateProviderRequestTransform("demo.conf", "demo", req)
 }
 
+func TestValidateRequestJSONOpsAcceptsModelChannelMaxPriceVariables(t *testing.T) {
+	resolved, err := validateValidationConf(t, `
+      json_set "$.provider.max_price.prompt" $model_channel.max_price.prompt;
+      json_set "$.provider.max_price.completion" $model_channel.max_price.completion;
+      json_set "$.provider.max_price.request" $model_channel.max_price.request;
+      json_set "$.provider.max_price.image" $model_channel.max_price.image;
+`)
+	if err != nil {
+		t.Fatalf("validateProviderRequestTransform: %v", err)
+	}
+	if len(resolved.Defaults.JSONOps) != 4 {
+		t.Fatalf("JSONOps len=%d, want 4", len(resolved.Defaults.JSONOps))
+	}
+}
+
 func mustValidateRules(t *testing.T, requestBody string) []RequestValidationRule {
 	t.Helper()
 	resolved, err := validateValidationConf(t, requestBody)

--- a/onr-core/pkg/dslconfig/routing.go
+++ b/onr-core/pkg/dslconfig/routing.go
@@ -279,6 +279,15 @@ func isBuiltinStringVariable(expr string) bool {
 	}
 }
 
+func isBuiltinJSONNumberVariable(expr string) bool {
+	switch strings.TrimSpace(expr) {
+	case exprModelChannelMaxPricePrompt, exprModelChannelMaxPriceCompletion, exprModelChannelMaxPriceRequest, exprModelChannelMaxPriceImage:
+		return true
+	default:
+		return false
+	}
+}
+
 func isQuotedStringExpr(expr string) bool {
 	raw := strings.TrimSpace(expr)
 	if len(raw) < 2 {

--- a/onr-core/pkg/dslconfig/sse_response_ops.go
+++ b/onr-core/pkg/dslconfig/sse_response_ops.go
@@ -294,14 +294,20 @@ func applyJSONOpsToObject(meta *dslmeta.Meta, obj map[string]any, ops []JSONOp, 
 		changed := false
 		switch op.Op {
 		case jsonOpSet:
-			val := evalJSONValueExpr(meta, op.ValueExpr)
+			val, err := evalJSONValueExpr(meta, op.ValueExpr)
+			if err != nil {
+				return err
+			}
 			opChanged, err := jsonSet(obj, op.Path, val)
 			if err != nil {
 				return err
 			}
 			changed = opChanged
 		case jsonOpReplace:
-			val := evalJSONValueExpr(meta, op.ValueExpr)
+			val, err := evalJSONValueExpr(meta, op.ValueExpr)
+			if err != nil {
+				return err
+			}
 			opChanged, err := jsonReplace(obj, op.Path, val)
 			if err != nil {
 				return err
@@ -315,7 +321,10 @@ func applyJSONOpsToObject(meta *dslmeta.Meta, obj map[string]any, ops []JSONOp, 
 			if exists {
 				continue
 			}
-			val := evalJSONValueExpr(meta, op.ValueExpr)
+			val, err := evalJSONValueExpr(meta, op.ValueExpr)
+			if err != nil {
+				return err
+			}
 			opChanged, err := jsonSet(obj, op.Path, val)
 			if err != nil {
 				return err

--- a/onr-core/pkg/dslconfig/validate_request_usage_finish.go
+++ b/onr-core/pkg/dslconfig/validate_request_usage_finish.go
@@ -197,6 +197,9 @@ func validateJSONValueExpr(expr string) error {
 	if _, ok := parseFloatLiteral(raw); ok {
 		return nil
 	}
+	if isBuiltinJSONNumberVariable(raw) {
+		return nil
+	}
 	return ValidateStringExpr(raw)
 }
 

--- a/onr-core/pkg/dslmeta/meta.go
+++ b/onr-core/pkg/dslmeta/meta.go
@@ -14,10 +14,10 @@ type TaskMeta struct {
 }
 
 type ModelChannelMaxPrice struct {
-	Prompt     float64
-	Completion float64
-	Request    float64
-	Image      float64
+	Prompt     *float64
+	Completion *float64
+	Request    *float64
+	Image      *float64
 }
 
 // Meta is the minimal context required by the DSL engine.

--- a/onr-core/pkg/dslmeta/meta.go
+++ b/onr-core/pkg/dslmeta/meta.go
@@ -13,6 +13,13 @@ type TaskMeta struct {
 	UpstreamID string
 }
 
+type ModelChannelMaxPrice struct {
+	Prompt     float64
+	Completion float64
+	Request    float64
+	Image      float64
+}
+
 // Meta is the minimal context required by the DSL engine.
 // It is intentionally small to keep open-next-router decoupled from other projects.
 type Meta struct {
@@ -45,6 +52,8 @@ type Meta struct {
 
 	// ChannelLocation is the provider location/region attached to the selected channel.
 	ChannelLocation string
+
+	ModelChannelMaxPrice *ModelChannelMaxPrice
 
 	// AWSAccessKeyID is the selected AWS access key id for SigV4 providers.
 	AWSAccessKeyID string


### PR DESCRIPTION
## Description

Adds numeric DSL variables for model-channel OpenRouter maximum prices:

```text
$model_channel.max_price.prompt
$model_channel.max_price.completion
$model_channel.max_price.request
$model_channel.max_price.image
```

These variables can be used as unquoted JSON value expressions in request transforms:

```conf
json_set "$.provider.max_price.prompt" $model_channel.max_price.prompt;
json_set "$.provider.max_price.completion" $model_channel.max_price.completion;
```

The values are emitted as JSON numbers rather than strings. Optional pointer fields preserve the distinction between an unconfigured price and an explicitly configured zero.

If a referenced numeric variable is unavailable, request transformation returns an error instead of falling back to string evaluation and writing the variable name into the request body.

The English and Chinese DSL documentation has been updated with the variables, supported contexts, examples, and missing-value behavior.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

The following tests were run:

```bash
go test ./pkg/dslmeta ./pkg/dslconfig ./pkg/requesttransform
```

Test coverage includes:

- DSL validation accepts all four model-channel max-price variables.
- Variables are evaluated as JSON numbers.
- Explicit zero remains a JSON number.
- Missing variables return a request-transform error.
- Partially configured prices report the specific missing variable.
- Existing numeric literals and string expressions retain their behavior.
- Relay metadata can pass optional price pointers without losing missing-value semantics.

- [ ] Manual test
- [x] Unit test
- [x] Integration test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules