### PR TITLE
feat: integrate asynchronous Meterry billing

### DIFF
--- a/config/onr.example.yaml
+++ b/config/onr.example.yaml
@@ -48,6 +48,21 @@ pricing:
   # This can also supplement models/cost fields missing from the synced price.yaml.
   overrides_file: "./price_overrides.yaml"
 
+meterry:
+  # Optional asynchronous usage billing through Meterry.
+  enabled: false
+  base_url: "https://billing.edgefn.dev"
+  project_id: ""
+  api_key: ""
+  extractor_rule_set_id: "ers_onr_gateway"
+  outbox_dir: "./run/meterry"
+  request_timeout_ms: 3000
+  retry_interval_ms: 1000
+  only_billable_success: true
+  subject_type: "api_key"
+  # Used for master-key or BYOK requests without a matched access key.
+  fallback_subject_id: ""
+
 upstream_proxies:
   # Configure outbound HTTP proxy per provider (optional).
   # Example:

--- a/onr/internal/auth/middleware.go
+++ b/onr/internal/auth/middleware.go
@@ -38,7 +38,10 @@ func Middleware(masterKey string, matchAccessKey AccessKeyMatcher, tokenOpts ...
 			return
 		}
 		if matchAccessKey != nil {
-			if _, ok := matchAccessKey(got); ok {
+			if name, ok := matchAccessKey(got); ok {
+				if strings.TrimSpace(name) != "" {
+					c.Set("onr.auth_subject_id", strings.TrimSpace(name))
+				}
 				c.Next()
 				return
 			}
@@ -62,6 +65,11 @@ func Middleware(masterKey string, matchAccessKey AccessKeyMatcher, tokenOpts ...
 					ok = true
 				}
 				if ok {
+					if strings.TrimSpace(accessKey) != "" && matchAccessKey != nil {
+						if name, matched := matchAccessKey(accessKey); matched && strings.TrimSpace(name) != "" {
+							c.Set("onr.auth_subject_id", strings.TrimSpace(name))
+						}
+					}
 					if claims.Provider != "" {
 						c.Set(ctxTokenProvider, claims.Provider)
 					}

--- a/onr/internal/auth/middleware_test.go
+++ b/onr/internal/auth/middleware_test.go
@@ -20,7 +20,13 @@ func TestMiddleware_TokenKey_AccessKey(t *testing.T) {
 	}
 	r := gin.New()
 	r.Use(Middleware("master", match))
-	r.GET("/ok", func(c *gin.Context) { c.String(200, "ok") })
+	r.GET("/ok", func(c *gin.Context) {
+		if got := c.GetString("onr.auth_subject_id"); got != "client1" {
+			c.String(http.StatusInternalServerError, "subject=%s", got)
+			return
+		}
+		c.String(200, "ok")
+	})
 
 	k64 := base64.RawURLEncoding.EncodeToString([]byte("ak-1"))
 	req := httptest.NewRequest(http.MethodGet, "/ok", nil)

--- a/onr/internal/meterry/client.go
+++ b/onr/internal/meterry/client.go
@@ -99,7 +99,7 @@ func (c *Client) worker() {
 	}
 }
 
-func (c *Client) send(event Event) error {
+func (c *Client) send(event Event) (retErr error) {
 	body, err := json.Marshal(event)
 	if err != nil {
 		return err
@@ -115,7 +115,11 @@ func (c *Client) send(event Event) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); retErr == nil && closeErr != nil {
+			retErr = closeErr
+		}
+	}()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		limited, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
 		return fmt.Errorf("meterry ingest returned %s: %s", resp.Status, strings.TrimSpace(string(limited)))

--- a/onr/internal/meterry/client.go
+++ b/onr/internal/meterry/client.go
@@ -25,12 +25,13 @@ type Config struct {
 }
 
 type Client struct {
-	cfg    Config
-	outbox *outbox
-	http   *http.Client
-	stop   chan struct{}
-	done   chan struct{}
-	once   sync.Once
+	cfg       Config
+	ingestURL string
+	outbox    *outbox
+	http      *http.Client
+	stop      chan struct{}
+	done      chan struct{}
+	once      sync.Once
 }
 
 func New(cfg Config) (*Client, error) {
@@ -51,11 +52,12 @@ func New(cfg Config) (*Client, error) {
 		cfg.RetryInterval = time.Second
 	}
 	c := &Client{
-		cfg:    cfg,
-		outbox: box,
-		http:   &http.Client{Timeout: cfg.RequestTimeout},
-		stop:   make(chan struct{}),
-		done:   make(chan struct{}),
+		cfg:       cfg,
+		ingestURL: strings.TrimRight(cfg.BaseURL, "/") + "/v1/projects/" + cfg.ProjectID + "/extractor-rule-sets/" + cfg.ExtractorRuleSet + "/events/ingest",
+		outbox:    box,
+		http:      &http.Client{Timeout: cfg.RequestTimeout},
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
 	}
 	go c.worker()
 	return c, nil
@@ -102,8 +104,7 @@ func (c *Client) send(event Event) error {
 	if err != nil {
 		return err
 	}
-	url := strings.TrimRight(c.cfg.BaseURL, "/") + "/v1/projects/" + c.cfg.ProjectID + "/extractor-rule-sets/" + c.cfg.ExtractorRuleSet + "/events/ingest"
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, c.ingestURL, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}

--- a/onr/internal/meterry/client.go
+++ b/onr/internal/meterry/client.go
@@ -1,0 +1,123 @@
+package meterry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Config struct {
+	Enabled          bool
+	BaseURL          string
+	ProjectID        string
+	APIKey           string
+	ExtractorRuleSet string
+	OutboxDir        string
+	RequestTimeout   time.Duration
+	RetryInterval    time.Duration
+}
+
+type Client struct {
+	cfg    Config
+	outbox *outbox
+	http   *http.Client
+	stop   chan struct{}
+	done   chan struct{}
+	once   sync.Once
+}
+
+func New(cfg Config) (*Client, error) {
+	if !cfg.Enabled {
+		return &Client{cfg: cfg}, nil
+	}
+	if strings.TrimSpace(cfg.BaseURL) == "" || strings.TrimSpace(cfg.ProjectID) == "" || strings.TrimSpace(cfg.APIKey) == "" || strings.TrimSpace(cfg.ExtractorRuleSet) == "" {
+		return nil, errors.New("meterry enabled requires base_url, project_id, api_key, and extractor_rule_set_id")
+	}
+	box, err := openOutbox(cfg.OutboxDir)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.RequestTimeout <= 0 {
+		cfg.RequestTimeout = 3 * time.Second
+	}
+	if cfg.RetryInterval <= 0 {
+		cfg.RetryInterval = time.Second
+	}
+	c := &Client{
+		cfg:    cfg,
+		outbox: box,
+		http:   &http.Client{Timeout: cfg.RequestTimeout},
+		stop:   make(chan struct{}),
+		done:   make(chan struct{}),
+	}
+	go c.worker()
+	return c, nil
+}
+
+func (c *Client) Enabled() bool { return c != nil && c.cfg.Enabled }
+
+func (c *Client) Enqueue(event Event) error {
+	if !c.Enabled() {
+		return nil
+	}
+	return c.outbox.append(event)
+}
+
+func (c *Client) Close() error {
+	if !c.Enabled() {
+		return nil
+	}
+	c.once.Do(func() { close(c.stop) })
+	<-c.done
+	return nil
+}
+
+func (c *Client) worker() {
+	defer close(c.done)
+	for {
+		event, err := c.outbox.first()
+		if err == nil {
+			if err := c.send(event); err == nil {
+				_ = c.outbox.ack(event.IdempotencyKey)
+				continue
+			}
+		}
+		select {
+		case <-c.stop:
+			return
+		case <-time.After(c.cfg.RetryInterval):
+		}
+	}
+}
+
+func (c *Client) send(event Event) error {
+	body, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	url := strings.TrimRight(c.cfg.BaseURL, "/") + "/v1/projects/" + c.cfg.ProjectID + "/extractor-rule-sets/" + c.cfg.ExtractorRuleSet + "/events/ingest"
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.cfg.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", event.IdempotencyKey)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		limited, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		return fmt.Errorf("meterry ingest returned %s: %s", resp.Status, strings.TrimSpace(string(limited)))
+	}
+	return nil
+}

--- a/onr/internal/meterry/client_test.go
+++ b/onr/internal/meterry/client_test.go
@@ -1,0 +1,50 @@
+package meterry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestClientSendsQueuedEvent(t *testing.T) {
+	received := make(chan Event, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var e Event
+		if err := json.NewDecoder(r.Body).Decode(&e); err != nil {
+			t.Errorf("decode event: %v", err)
+		}
+		received <- e
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	c, err := New(Config{
+		Enabled:          true,
+		BaseURL:          srv.URL,
+		ProjectID:        "proj",
+		APIKey:           "secret",
+		ExtractorRuleSet: "ers",
+		OutboxDir:        t.TempDir(),
+		RetryInterval:    5 * time.Millisecond,
+		RequestTimeout:   time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := NewEvent("rid_1", "openai", "chat.completions", "m", false, 200, "upstream", nil, "api_key", "k", "", nil)
+	if err := c.Enqueue(e); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case got := <-received:
+		if got.IdempotencyKey != e.IdempotencyKey {
+			t.Fatalf("idempotency key = %q", got.IdempotencyKey)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Meterry ingest")
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/onr/internal/meterry/event.go
+++ b/onr/internal/meterry/event.go
@@ -1,0 +1,129 @@
+package meterry
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Event is the normalized, non-sensitive usage payload sent to Meterry.
+type Event struct {
+	Source          string         `json:"source"`
+	ExternalEventID string         `json:"external_event_id"`
+	IdempotencyKey  string         `json:"idempotency_key"`
+	OccurredAt      int64          `json:"occurred_at"`
+	SubjectType     string         `json:"subject_type,omitempty"`
+	SubjectID       string         `json:"subject_id,omitempty"`
+	RawJSON         map[string]any `json:"raw_json"`
+	Billing         map[string]any `json:"x-billing,omitempty"`
+	Metadata        map[string]any `json:"metadata,omitempty"`
+}
+
+func NewEvent(requestID string, provider string, api string, model string, stream bool, status int, usageStage string, usage map[string]any, subjectType string, subjectID string, appname string, pricingHints map[string]any) Event {
+	rid := strings.TrimSpace(requestID)
+	provider = strings.TrimSpace(provider)
+	api = strings.TrimSpace(api)
+	model = strings.TrimSpace(model)
+	subjectType = strings.TrimSpace(subjectType)
+	subjectID = strings.TrimSpace(subjectID)
+	usage = normalizeUsageAliases(usage)
+	raw := map[string]any{
+		"provider":    provider,
+		"api":         api,
+		"model":       model,
+		"stream":      stream,
+		"status":      status,
+		"usage_stage": strings.TrimSpace(usageStage),
+		"usage":       cloneMap(usage),
+		"meta": map[string]any{
+			"subject_type": subjectType,
+			"subject_id":   subjectID,
+			"request_id":   rid,
+		},
+	}
+	if appname = strings.TrimSpace(appname); appname != "" {
+		raw["meta"].(map[string]any)["appname"] = appname
+	}
+	e := Event{
+		Source:          "open-next-router",
+		ExternalEventID: rid,
+		IdempotencyKey:  fmt.Sprintf("onr:%s", rid),
+		OccurredAt:      time.Now().Unix(),
+		SubjectType:     subjectType,
+		SubjectID:       subjectID,
+		RawJSON:         raw,
+	}
+	if len(pricingHints) > 0 {
+		e.Billing = map[string]any{
+			"items":         billingItems(usage),
+			"pricing_hints": cloneMap(pricingHints),
+		}
+	} else if items := billingItems(usage); len(items) > 0 {
+		e.Billing = map[string]any{"items": items}
+	}
+	return e
+}
+
+func billingItems(usage map[string]any) []map[string]any {
+	if len(usage) == 0 {
+		return nil
+	}
+	items := make([]map[string]any, 0, 4)
+	for metric, key := range map[string]string{
+		"prompt_tokens":     "input_tokens",
+		"completion_tokens": "output_tokens",
+		"cached_tokens":     "cache_read_tokens",
+	} {
+		if value, ok := usage[key]; ok && numberPositive(value) {
+			items = append(items, map[string]any{"metric": metric, "quantity": value, "unit": "token"})
+		}
+	}
+	return items
+}
+
+func numberPositive(v any) bool {
+	switch n := v.(type) {
+	case int:
+		return n > 0
+	case int64:
+		return n > 0
+	case float64:
+		return n > 0
+	default:
+		return false
+	}
+}
+
+func normalizeUsageAliases(in map[string]any) map[string]any {
+	out := cloneMap(in)
+	if len(out) == 0 {
+		return out
+	}
+	if _, ok := out["prompt_tokens"]; !ok {
+		if v, ok := out["input_tokens"]; ok {
+			out["prompt_tokens"] = v
+		}
+	}
+	if _, ok := out["completion_tokens"]; !ok {
+		if v, ok := out["output_tokens"]; ok {
+			out["completion_tokens"] = v
+		}
+	}
+	if _, ok := out["cached_tokens"]; !ok {
+		if v, ok := out["cache_read_tokens"]; ok {
+			out["cached_tokens"] = v
+		}
+	}
+	return out
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/onr/internal/meterry/event_test.go
+++ b/onr/internal/meterry/event_test.go
@@ -1,0 +1,29 @@
+package meterry
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNewEventContainsOnlyBillingMetadata(t *testing.T) {
+	e := NewEvent("rid_1", "openai", "chat.completions", "gpt-4.1-mini", true, 200, "upstream", map[string]any{"input_tokens": 12}, "api_key", "key_1", "client", map[string]any{"input_tokens": map[string]any{"unit_price": "1.0"}})
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) == "" || string(b) == "{}" {
+		t.Fatalf("unexpected event JSON: %s", b)
+	}
+	if e.RawJSON["request_body"] != nil {
+		t.Fatalf("event must not contain request body")
+	}
+	if e.IdempotencyKey != "onr:rid_1" {
+		t.Fatalf("idempotency key = %q", e.IdempotencyKey)
+	}
+	if e.SubjectType != "api_key" || e.SubjectID != "key_1" {
+		t.Fatalf("subject = %s/%s", e.SubjectType, e.SubjectID)
+	}
+	if got := e.RawJSON["usage"].(map[string]any)["prompt_tokens"]; got != 12 {
+		t.Fatalf("prompt_tokens alias = %#v", got)
+	}
+}

--- a/onr/internal/meterry/outbox.go
+++ b/onr/internal/meterry/outbox.go
@@ -1,0 +1,129 @@
+package meterry
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+type outbox struct {
+	mu   sync.Mutex
+	path string
+}
+
+func openOutbox(dir string) (*outbox, error) {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return nil, errors.New("meterry outbox directory is empty")
+	}
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return nil, fmt.Errorf("create meterry outbox directory: %w", err)
+	}
+	return &outbox{path: filepath.Join(dir, "events.jsonl")}, nil
+}
+
+func (o *outbox) append(event Event) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	f, err := os.OpenFile(o.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	b, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		return err
+	}
+	return f.Sync()
+}
+
+func (o *outbox) first() (Event, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	f, err := os.Open(o.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return Event{}, io.EOF
+	}
+	if err != nil {
+		return Event{}, err
+	}
+	defer f.Close()
+	s := bufio.NewScanner(f)
+	if !s.Scan() {
+		if err := s.Err(); err != nil {
+			return Event{}, err
+		}
+		return Event{}, io.EOF
+	}
+	var event Event
+	if err := json.Unmarshal(s.Bytes(), &event); err != nil {
+		return Event{}, fmt.Errorf("decode meterry outbox event: %w", err)
+	}
+	return event, nil
+}
+
+func (o *outbox) ack(idempotencyKey string) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	f, err := os.Open(o.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	tmp, err := os.CreateTemp(filepath.Dir(o.path), ".events-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	keepFirst := true
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		line := s.Bytes()
+		var event Event
+		if err := json.Unmarshal(line, &event); err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmpPath)
+			return fmt.Errorf("decode meterry outbox event while acking: %w", err)
+		}
+		if keepFirst && event.IdempotencyKey == idempotencyKey {
+			keepFirst = false
+			continue
+		}
+		if _, err := tmp.Write(append(line, '\n')); err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmpPath)
+			return err
+		}
+	}
+	if err := s.Err(); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, o.path); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}

--- a/onr/internal/meterry/outbox.go
+++ b/onr/internal/meterry/outbox.go
@@ -35,15 +35,20 @@ func (o *outbox) append(event Event) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 	b, err := json.Marshal(event)
 	if err != nil {
+		_ = f.Close()
 		return err
 	}
 	if _, err := f.Write(append(b, '\n')); err != nil {
+		_ = f.Close()
 		return err
 	}
-	return f.Sync()
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
 }
 
 func (o *outbox) first() (Event, error) {
@@ -56,22 +61,29 @@ func (o *outbox) first() (Event, error) {
 	if err != nil {
 		return Event{}, err
 	}
-	defer f.Close()
 	s := bufio.NewScanner(f)
 	if !s.Scan() {
 		if err := s.Err(); err != nil {
+			_ = f.Close()
+			return Event{}, err
+		}
+		if err := f.Close(); err != nil {
 			return Event{}, err
 		}
 		return Event{}, io.EOF
 	}
 	var event Event
 	if err := json.Unmarshal(s.Bytes(), &event); err != nil {
+		_ = f.Close()
 		return Event{}, fmt.Errorf("decode meterry outbox event: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return Event{}, err
 	}
 	return event, nil
 }
 
-func (o *outbox) ack(idempotencyKey string) error {
+func (o *outbox) ack(idempotencyKey string) (retErr error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	f, err := os.Open(o.path)
@@ -81,7 +93,11 @@ func (o *outbox) ack(idempotencyKey string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		if closeErr := f.Close(); retErr == nil && closeErr != nil {
+			retErr = closeErr
+		}
+	}()
 	tmp, err := os.CreateTemp(filepath.Dir(o.path), ".events-*.tmp")
 	if err != nil {
 		return err

--- a/onr/internal/meterry/outbox_test.go
+++ b/onr/internal/meterry/outbox_test.go
@@ -1,0 +1,39 @@
+package meterry
+
+import (
+	"io"
+	"testing"
+)
+
+func TestOutboxAppendFirstAck(t *testing.T) {
+	dir := t.TempDir()
+	o, err := openOutbox(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	one := NewEvent("rid_1", "openai", "chat.completions", "m", false, 200, "upstream", nil, "api_key", "k", "", nil)
+	two := NewEvent("rid_2", "openai", "chat.completions", "m", false, 200, "upstream", nil, "api_key", "k", "", nil)
+	if err := o.append(one); err != nil {
+		t.Fatal(err)
+	}
+	if err := o.append(two); err != nil {
+		t.Fatal(err)
+	}
+	got, err := o.first()
+	if err != nil || got.IdempotencyKey != one.IdempotencyKey {
+		t.Fatalf("first = %#v, err=%v", got, err)
+	}
+	if err := o.ack(one.IdempotencyKey); err != nil {
+		t.Fatal(err)
+	}
+	got, err = o.first()
+	if err != nil || got.IdempotencyKey != two.IdempotencyKey {
+		t.Fatalf("after ack first = %#v, err=%v", got, err)
+	}
+	if err := o.ack(two.IdempotencyKey); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := o.first(); err != io.EOF {
+		t.Fatalf("empty outbox err=%v, want EOF", err)
+	}
+}

--- a/onr/internal/onrserver/billing.go
+++ b/onr/internal/onrserver/billing.go
@@ -1,0 +1,106 @@
+package onrserver
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/r9s-ai/open-next-router/onr/internal/meterry"
+	"github.com/r9s-ai/open-next-router/onr/internal/proxy"
+	"github.com/r9s-ai/open-next-router/pkg/config"
+)
+
+func enqueueBillingEvent(cfg *config.Config, sink *meterry.Client, c *gin.Context, res *proxy.Result) {
+	if cfg == nil || sink == nil || !sink.Enabled() || c == nil || res == nil {
+		return
+	}
+	if cfg.Meterry.OnlyBillableSuccess != nil && *cfg.Meterry.OnlyBillableSuccess && (res.Status < 200 || res.Status >= 300) {
+		return
+	}
+	rid := strings.TrimSpace(c.GetString("X-Onr-Request-Id"))
+	if rid == "" {
+		rid = strings.TrimSpace(c.GetString("X-Request-Id"))
+	}
+	subjectID := strings.TrimSpace(c.GetString("onr.auth_subject_id"))
+	if subjectID == "" {
+		subjectID = strings.TrimSpace(cfg.Meterry.FallbackSubjectID)
+	}
+	if subjectID == "" {
+		return
+	}
+	var appname string
+	if c.Request != nil {
+		appname = c.GetHeader("appname")
+	}
+	event := meterry.NewEvent(
+		rid,
+		res.Provider,
+		res.API,
+		res.Model,
+		res.Stream,
+		res.Status,
+		res.UsageStage,
+		res.Usage,
+		cfg.Meterry.SubjectType,
+		subjectID,
+		appname,
+		pricingHints(res.Cost),
+	)
+	if err := sink.Enqueue(event); err != nil {
+		// Billing is deliberately best-effort for the request path. The sink owns
+		// retryable delivery once the event is durably queued.
+		return
+	}
+}
+
+func pricingHints(cost map[string]any) map[string]any {
+	if len(cost) == 0 {
+		return nil
+	}
+	unit := numberOr(cost["cost_rate_unit"], 1000000)
+	currency := "USD"
+	if v, ok := cost["cost_unit"].(string); ok && strings.TrimSpace(v) != "" {
+		currency = strings.ToUpper(strings.TrimSpace(v))
+	}
+	out := map[string]any{}
+	for metric, key := range map[string]string{
+		"input_tokens":       "price_input",
+		"output_tokens":      "price_output",
+		"cache_read_tokens":  "price_cache_read",
+		"cache_write_tokens": "price_cache_write",
+	} {
+		if price, ok := cost[key]; ok && numberPositive(price) {
+			out[metric] = map[string]any{"unit_price": price, "pricing_unit": unit, "currency": currency}
+		}
+	}
+	if v, ok := out["input_tokens"]; ok {
+		out["prompt_tokens"] = v
+	}
+	if v, ok := out["output_tokens"]; ok {
+		out["completion_tokens"] = v
+	}
+	if v, ok := out["cache_read_tokens"]; ok {
+		out["cached_tokens"] = v
+	}
+	return out
+}
+
+func numberPositive(v any) bool {
+	switch n := v.(type) {
+	case int:
+		return n > 0
+	case int64:
+		return n > 0
+	case float64:
+		return n > 0
+	default:
+		return false
+	}
+}
+
+func numberOr(v any, fallback int) any {
+	if numberPositive(v) {
+		return v
+	}
+	return fallback
+}

--- a/onr/internal/onrserver/gemini.go
+++ b/onr/internal/onrserver/gemini.go
@@ -10,11 +10,12 @@ import (
 	"github.com/r9s-ai/open-next-router/onr-core/pkg/requestid"
 	"github.com/r9s-ai/open-next-router/onr-core/pkg/trafficdump"
 	"github.com/r9s-ai/open-next-router/onr/internal/auth"
+	"github.com/r9s-ai/open-next-router/onr/internal/meterry"
 	"github.com/r9s-ai/open-next-router/onr/internal/proxy"
 	"github.com/r9s-ai/open-next-router/pkg/config"
 )
 
-func makeGeminiHandler(cfg *config.Config, st *state, pclient *proxy.Client, requestIDHeaderKey string) gin.HandlerFunc {
+func makeGeminiHandler(cfg *config.Config, st *state, pclient *proxy.Client, requestIDHeaderKey string, billing *meterry.Client) gin.HandlerFunc {
 	requestIDHeaderKey = requestid.ResolveHeaderKey(requestIDHeaderKey)
 	return func(c *gin.Context) {
 		model, action, err := parseGeminiModelAction(c.Param("path"))
@@ -129,6 +130,7 @@ func makeGeminiHandler(cfg *config.Config, st *state, pclient *proxy.Client, req
 			return
 		}
 		setProxyResultContext(c, res)
+		enqueueBillingEvent(cfg, billing, c, res)
 
 		_ = cfg
 	}

--- a/onr/internal/onrserver/handlers.go
+++ b/onr/internal/onrserver/handlers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/r9s-ai/open-next-router/onr-core/pkg/requestvalidate"
 	"github.com/r9s-ai/open-next-router/onr-core/pkg/trafficdump"
 	"github.com/r9s-ai/open-next-router/onr/internal/auth"
+	"github.com/r9s-ai/open-next-router/onr/internal/meterry"
 	"github.com/r9s-ai/open-next-router/onr/internal/proxy"
 	"github.com/r9s-ai/open-next-router/pkg/config"
 )
@@ -28,7 +29,7 @@ const (
 	ctxKeyRequestContentType = "onr.request_content_type"
 )
 
-func makeHandler(cfg *config.Config, st *state, pclient *proxy.Client, api string, requestIDHeaderKey string) gin.HandlerFunc {
+func makeHandler(cfg *config.Config, st *state, pclient *proxy.Client, api string, requestIDHeaderKey string, billing *meterry.Client) gin.HandlerFunc {
 	requestIDHeaderKey = requestid.ResolveHeaderKey(requestIDHeaderKey)
 	return func(c *gin.Context) {
 		c.Set("onr.api", api)
@@ -115,6 +116,7 @@ func makeHandler(cfg *config.Config, st *state, pclient *proxy.Client, api strin
 			return
 		}
 		setProxyResultContext(c, res)
+		enqueueBillingEvent(cfg, billing, c, res)
 
 		_ = cfg
 	}

--- a/onr/internal/onrserver/router.go
+++ b/onr/internal/onrserver/router.go
@@ -12,6 +12,7 @@ import (
 	"github.com/r9s-ai/open-next-router/onr-core/pkg/trafficdump"
 	"github.com/r9s-ai/open-next-router/onr/internal/auth"
 	"github.com/r9s-ai/open-next-router/onr/internal/logx"
+	"github.com/r9s-ai/open-next-router/onr/internal/meterry"
 	"github.com/r9s-ai/open-next-router/onr/internal/proxy"
 	"github.com/r9s-ai/open-next-router/pkg/config"
 )
@@ -26,7 +27,12 @@ func NewRouter(
 	accessLoggerColor bool,
 	requestIDHeaderKey string,
 	accessFormatter *logx.AccessLogFormatter,
+	billing ...*meterry.Client,
 ) *gin.Engine {
+	var billingClient *meterry.Client
+	if len(billing) > 0 {
+		billingClient = billing[0]
+	}
 	resolvedRequestIDHeaderKey := requestid.ResolveHeaderKey(requestIDHeaderKey)
 	r := gin.New()
 	r.Use(requestIDMiddleware(resolvedRequestIDHeaderKey))
@@ -75,16 +81,16 @@ func NewRouter(
 	})
 
 	v1 := secured.Group("/v1")
-	v1.POST("/completions", makeHandler(cfg, st, pclient, "completions", resolvedRequestIDHeaderKey))
-	v1.POST("/chat/completions", makeHandler(cfg, st, pclient, "chat.completions", resolvedRequestIDHeaderKey))
-	v1.POST("/responses", makeHandler(cfg, st, pclient, "responses", resolvedRequestIDHeaderKey))
-	v1.POST("/embeddings", makeHandler(cfg, st, pclient, "embeddings", resolvedRequestIDHeaderKey))
-	v1.POST("/images/generations", makeHandler(cfg, st, pclient, "images.generations", resolvedRequestIDHeaderKey))
-	v1.POST("/images/edits", makeHandler(cfg, st, pclient, "images.edits", resolvedRequestIDHeaderKey))
-	v1.POST("/audio/speech", makeHandler(cfg, st, pclient, "audio.speech", resolvedRequestIDHeaderKey))
-	v1.POST("/audio/transcriptions", makeHandler(cfg, st, pclient, "audio.transcriptions", resolvedRequestIDHeaderKey))
-	v1.POST("/audio/translations", makeHandler(cfg, st, pclient, "audio.translations", resolvedRequestIDHeaderKey))
-	v1.POST("/messages", makeHandler(cfg, st, pclient, "claude.messages", resolvedRequestIDHeaderKey))
+	v1.POST("/completions", makeHandler(cfg, st, pclient, "completions", resolvedRequestIDHeaderKey, billingClient))
+	v1.POST("/chat/completions", makeHandler(cfg, st, pclient, "chat.completions", resolvedRequestIDHeaderKey, billingClient))
+	v1.POST("/responses", makeHandler(cfg, st, pclient, "responses", resolvedRequestIDHeaderKey, billingClient))
+	v1.POST("/embeddings", makeHandler(cfg, st, pclient, "embeddings", resolvedRequestIDHeaderKey, billingClient))
+	v1.POST("/images/generations", makeHandler(cfg, st, pclient, "images.generations", resolvedRequestIDHeaderKey, billingClient))
+	v1.POST("/images/edits", makeHandler(cfg, st, pclient, "images.edits", resolvedRequestIDHeaderKey, billingClient))
+	v1.POST("/audio/speech", makeHandler(cfg, st, pclient, "audio.speech", resolvedRequestIDHeaderKey, billingClient))
+	v1.POST("/audio/transcriptions", makeHandler(cfg, st, pclient, "audio.transcriptions", resolvedRequestIDHeaderKey, billingClient))
+	v1.POST("/audio/translations", makeHandler(cfg, st, pclient, "audio.translations", resolvedRequestIDHeaderKey, billingClient))
+	v1.POST("/messages", makeHandler(cfg, st, pclient, "claude.messages", resolvedRequestIDHeaderKey, billingClient))
 	v1.GET("/models", func(c *gin.Context) {
 		c.JSON(http.StatusOK, st.ModelRouter().ToOpenAIListAt(st.StartedAtUnix()))
 	})
@@ -108,7 +114,7 @@ func NewRouter(
 	})
 	// Gemini native API paths: /v1beta/models/{model}:generateContent
 	// (Stage 1) Only generateContent / streamGenerateContent are supported.
-	v1beta.POST("/models/*path", makeGeminiHandler(cfg, st, pclient, resolvedRequestIDHeaderKey))
+	v1beta.POST("/models/*path", makeGeminiHandler(cfg, st, pclient, resolvedRequestIDHeaderKey, billingClient))
 
 	return r
 }

--- a/onr/internal/onrserver/run.go
+++ b/onr/internal/onrserver/run.go
@@ -23,6 +23,7 @@ import (
 	"github.com/r9s-ai/open-next-router/onr-core/pkg/models"
 	"github.com/r9s-ai/open-next-router/onr-core/pkg/pricing"
 	"github.com/r9s-ai/open-next-router/onr/internal/logx"
+	"github.com/r9s-ai/open-next-router/onr/internal/meterry"
 	"github.com/r9s-ai/open-next-router/onr/internal/proxy"
 	"github.com/r9s-ai/open-next-router/pkg/config"
 )
@@ -101,6 +102,22 @@ func Run(cfgPath string) error {
 	}
 	pclient.SetPricingResolver(pricingResolver)
 	pclient.SetPricingEnabled(cfg.Pricing.Enabled)
+	meterryClient, err := meterry.New(meterry.Config{
+		Enabled:          cfg.Meterry.Enabled,
+		BaseURL:          cfg.Meterry.BaseURL,
+		ProjectID:        cfg.Meterry.ProjectID,
+		APIKey:           cfg.Meterry.APIKey,
+		ExtractorRuleSet: cfg.Meterry.ExtractorRuleSet,
+		OutboxDir:        cfg.Meterry.OutboxDir,
+		RequestTimeout:   cfg.Meterry.RequestTimeout(),
+		RetryInterval:    cfg.Meterry.RetryInterval(),
+	})
+	if err != nil {
+		return fmt.Errorf("init meterry billing: %w", err)
+	}
+	if meterryClient != nil && meterryClient.Enabled() {
+		defer func() { _ = meterryClient.Close() }()
+	}
 
 	st := &state{
 		keys:        keys,
@@ -126,7 +143,7 @@ func Run(cfgPath string) error {
 	if err != nil {
 		return fmt.Errorf("compile access_log_format: %w", err)
 	}
-	engine := NewRouter(cfg, st, reg, pclient, accessLogger, accessColor, "X-Onr-Request-Id", accessFormatter)
+	engine := NewRouter(cfg, st, reg, pclient, accessLogger, accessColor, "X-Onr-Request-Id", accessFormatter, meterryClient)
 
 	logStartupSummary(sysLogger, cfg, cfgPath)
 	sysLogger.Info(logx.SystemCategoryServer, "open-next-router listening", map[string]any{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/r9s-ai/open-next-router/onr-core/pkg/usageestimate"
 	"gopkg.in/yaml.v3"
@@ -96,6 +97,20 @@ type LoggingConfig struct {
 	AppNameInfer          AppNameInferConfig    `yaml:"appname_infer"`
 }
 
+type MeterryConfig struct {
+	Enabled             bool   `yaml:"enabled"`
+	BaseURL             string `yaml:"base_url"`
+	ProjectID           string `yaml:"project_id"`
+	APIKey              string `yaml:"api_key"`
+	ExtractorRuleSet    string `yaml:"extractor_rule_set_id"`
+	OutboxDir           string `yaml:"outbox_dir"`
+	RequestTimeoutMs    int    `yaml:"request_timeout_ms"`
+	RetryIntervalMs     int    `yaml:"retry_interval_ms"`
+	OnlyBillableSuccess *bool  `yaml:"only_billable_success"`
+	SubjectType         string `yaml:"subject_type"`
+	FallbackSubjectID   string `yaml:"fallback_subject_id"`
+}
+
 type Config struct {
 	Server struct {
 		Listen         string `yaml:"listen"`
@@ -155,6 +170,7 @@ type Config struct {
 	} `yaml:"upstream_proxies"`
 
 	UsageEstimation usageestimate.Config `yaml:"usage_estimation"`
+	Meterry         MeterryConfig        `yaml:"meterry"`
 
 	TrafficDump struct {
 		Enabled     bool     `yaml:"enabled"`
@@ -281,6 +297,22 @@ func applyDefaults(cfg *Config) {
 	if strings.TrimSpace(cfg.TrafficDump.Dir) == "" {
 		cfg.TrafficDump.Dir = "./dumps"
 	}
+	if strings.TrimSpace(cfg.Meterry.OutboxDir) == "" {
+		cfg.Meterry.OutboxDir = "./run/meterry"
+	}
+	if cfg.Meterry.RequestTimeoutMs <= 0 {
+		cfg.Meterry.RequestTimeoutMs = 3000
+	}
+	if cfg.Meterry.RetryIntervalMs <= 0 {
+		cfg.Meterry.RetryIntervalMs = 1000
+	}
+	if strings.TrimSpace(cfg.Meterry.SubjectType) == "" {
+		cfg.Meterry.SubjectType = "api_key"
+	}
+	if cfg.Meterry.OnlyBillableSuccess == nil {
+		v := true
+		cfg.Meterry.OnlyBillableSuccess = &v
+	}
 	if strings.TrimSpace(cfg.TrafficDump.FilePath) == "" {
 		cfg.TrafficDump.FilePath = "{{.request_id}}.log"
 	}
@@ -313,8 +345,34 @@ func applyEnvOverrides(cfg *Config) {
 	applyEnvServerAuthOverrides(cfg)
 	applyEnvProviderAndDataOverrides(cfg)
 	applyProviderProxyEnvOverrides(cfg)
+	applyEnvMeterryOverrides(cfg)
 	applyEnvTrafficDumpOverrides(cfg)
 	applyEnvLoggingOverrides(cfg)
+}
+
+func applyEnvMeterryOverrides(cfg *Config) {
+	cfg.Meterry.Enabled = envBool("ONR_METERRY_ENABLED", cfg.Meterry.Enabled)
+	if v := strings.TrimSpace(os.Getenv("ONR_METERRY_BASE_URL")); v != "" {
+		cfg.Meterry.BaseURL = v
+	}
+	if v := strings.TrimSpace(os.Getenv("ONR_METERRY_PROJECT_ID")); v != "" {
+		cfg.Meterry.ProjectID = v
+	}
+	if v := strings.TrimSpace(os.Getenv("ONR_METERRY_API_KEY")); v != "" {
+		cfg.Meterry.APIKey = v
+	}
+	if v := strings.TrimSpace(os.Getenv("ONR_METERRY_EXTRACTOR_RULE_SET_ID")); v != "" {
+		cfg.Meterry.ExtractorRuleSet = v
+	}
+	if v := strings.TrimSpace(os.Getenv("ONR_METERRY_OUTBOX_DIR")); v != "" {
+		cfg.Meterry.OutboxDir = v
+	}
+	if n, ok := envInt("ONR_METERRY_REQUEST_TIMEOUT_MS"); ok && n > 0 {
+		cfg.Meterry.RequestTimeoutMs = n
+	}
+	if n, ok := envInt("ONR_METERRY_RETRY_INTERVAL_MS"); ok && n > 0 {
+		cfg.Meterry.RetryIntervalMs = n
+	}
 }
 
 func applyEnvServerAuthOverrides(cfg *Config) {
@@ -475,7 +533,23 @@ func validate(cfg *Config) error {
 	if cfg.Logging.AccessLogRotate.MaxAgeDays < 0 {
 		return errors.New("logging.access_log_rotate.max_age_days must be >= 0")
 	}
+	if cfg.Meterry.Enabled {
+		if strings.TrimSpace(cfg.Meterry.BaseURL) == "" || strings.TrimSpace(cfg.Meterry.ProjectID) == "" || strings.TrimSpace(cfg.Meterry.APIKey) == "" || strings.TrimSpace(cfg.Meterry.ExtractorRuleSet) == "" {
+			return errors.New("meterry requires base_url, project_id, api_key, and extractor_rule_set_id when enabled")
+		}
+		if cfg.Meterry.RequestTimeoutMs <= 0 || cfg.Meterry.RetryIntervalMs <= 0 {
+			return errors.New("meterry request_timeout_ms and retry_interval_ms must be > 0")
+		}
+	}
 	return nil
+}
+
+func (c MeterryConfig) RequestTimeout() time.Duration {
+	return time.Duration(c.RequestTimeoutMs) * time.Millisecond
+}
+
+func (c MeterryConfig) RetryInterval() time.Duration {
+	return time.Duration(c.RetryIntervalMs) * time.Millisecond
 }
 
 func normalizeLogLevel(level string) (string, error) {


### PR DESCRIPTION
## Summary
- add asynchronous Meterry ingest with a durable JSONL outbox and retry worker
- emit usage, subject, billing items, pricing hints, and idempotency metadata from ONR responses
- add Meterry configuration and environment-backed settings
- update the onr-docs submodule to the English Meterry integration guide

## Verification
- go test ./...
- git diff --check

## Related
- Documentation PR: https://github.com/r9s-ai/onr-docs/pull/6

## Notes
- The existing unrelated onr-lsp submodule worktree change was left untouched and is not included in this PR.